### PR TITLE
clean up (a majority of) clippy warnings

### DIFF
--- a/src/columns/command.rs
+++ b/src/columns/command.rs
@@ -32,9 +32,9 @@ impl Column for Command {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let content = if let Ok(cmd) = &curr_proc.cmdline() {
-            if cmd.len() != 0 {
+            if !cmd.is_empty() {
                 let mut cmd = cmd
                     .iter()
                     .cloned()
@@ -55,7 +55,7 @@ impl Column for Command {
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/cpu_time.rs
+++ b/src/columns/cpu_time.rs
@@ -32,15 +32,15 @@ impl Column for CpuTime {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let time_sec = (curr_proc.stat.utime + curr_proc.stat.stime)
             / procfs::ticks_per_second().unwrap_or(100) as u64;
 
-        let content = format!("{}", util::parse_time(time_sec));
+        let content = util::parse_time(time_sec).to_string();
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/pid.rs
+++ b/src/columns/pid.rs
@@ -32,12 +32,12 @@ impl Column for Pid {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let content = format!("{}", curr_proc.pid());
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/read_bytes.rs
+++ b/src/columns/read_bytes.rs
@@ -32,7 +32,7 @@ impl Column for ReadBytes {
         curr_io: &ProcResult<Io>,
         prev_io: &ProcResult<Io>,
         interval: &Duration,
-    ) -> () {
+    ) {
         let content = if curr_io.is_ok() && prev_io.is_ok() {
             let interval_ms = interval.as_secs() + interval.subsec_millis() as u64;
             let io = (curr_io.as_ref().unwrap().read_bytes - prev_io.as_ref().unwrap().read_bytes)
@@ -46,7 +46,7 @@ impl Column for ReadBytes {
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/separator.rs
+++ b/src/columns/separator.rs
@@ -32,12 +32,12 @@ impl Column for Separator {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
-        let content = format!("|");
+    ) {
+        let content = "|".to_string();
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/start_time.rs
+++ b/src/columns/start_time.rs
@@ -32,13 +32,13 @@ impl Column for StartTime {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let start_time = curr_proc.stat.starttime();
         let content = format!("{}", start_time.format("%Y/%m/%d %H:%M"));
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/state.rs
+++ b/src/columns/state.rs
@@ -32,12 +32,12 @@ impl Column for State {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let content = format!("{}", curr_proc.stat.state);
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/tcp_port.rs
+++ b/src/columns/tcp_port.rs
@@ -34,13 +34,12 @@ impl Column for TcpPort {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let mut socks = Vec::new();
         if let Ok(fds) = curr_proc.fd() {
             for fd in fds {
-                match fd.target {
-                    FDTarget::Socket(x) => socks.push(x),
-                    _ => (),
+                if let FDTarget::Socket(x) = fd.target {
+                    socks.push(x)
                 }
             }
         }
@@ -57,13 +56,13 @@ impl Column for TcpPort {
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     fn find_exact(&self, pid: i32, keyword: &str) -> bool {
         if let Some(content) = self.contents().get(&pid) {
             let content = content.replace("[", "").replace("]", "");
-            let content = content.split(",");
+            let content = content.split(',');
             for c in content {
                 if c == keyword {
                     return true;

--- a/src/columns/tty.rs
+++ b/src/columns/tty.rs
@@ -32,7 +32,7 @@ impl Column for Tty {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let (major, minor) = curr_proc.stat.tty_nr();
         let content = if major == 136 {
             format!("pts/{}", minor)
@@ -42,7 +42,7 @@ impl Column for Tty {
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/udp_port.rs
+++ b/src/columns/udp_port.rs
@@ -34,13 +34,12 @@ impl Column for UdpPort {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let mut socks = Vec::new();
         if let Ok(fds) = curr_proc.fd() {
             for fd in fds {
-                match fd.target {
-                    FDTarget::Socket(x) => socks.push(x),
-                    _ => (),
+                if let FDTarget::Socket(x) = fd.target {
+                    socks.push(x)
                 }
             }
         }
@@ -55,13 +54,13 @@ impl Column for UdpPort {
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     fn find_exact(&self, pid: i32, keyword: &str) -> bool {
         if let Some(content) = self.contents().get(&pid) {
             let content = content.replace("[", "").replace("]", "");
-            let content = content.split(",");
+            let content = content.split(',');
             for c in content {
                 if c == keyword {
                     return true;

--- a/src/columns/usage_cpu.rs
+++ b/src/columns/usage_cpu.rs
@@ -32,7 +32,7 @@ impl Column for UsageCpu {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         interval: &Duration,
-    ) -> () {
+    ) {
         let curr_time = curr_proc.stat.utime + curr_proc.stat.stime;
         let prev_time = prev_proc.stat.utime + prev_proc.stat.stime;
         let usage_ms =
@@ -43,7 +43,7 @@ impl Column for UsageCpu {
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/usage_mem.rs
+++ b/src/columns/usage_mem.rs
@@ -34,13 +34,13 @@ impl Column for UsageMem {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let usage = curr_proc.stat.rss_bytes();
         let content = format!("{:.1}", usage as f64 * 100.0 / self.mem_total as f64);
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/username.rs
+++ b/src/columns/username.rs
@@ -32,7 +32,7 @@ impl Column for Username {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let user = users::get_user_by_uid(curr_proc.owner);
         let content = if let Some(user) = user {
             format!("{}", user.name().to_string_lossy())
@@ -42,7 +42,7 @@ impl Column for Username {
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/vm_rss.rs
+++ b/src/columns/vm_rss.rs
@@ -32,13 +32,13 @@ impl Column for VmRss {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let (size, unit) = unbytify::bytify(curr_proc.stat.rss_bytes() as u64);
         let content = format!("{}{}", size, unit.replace("i", "").replace("B", ""));
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/vm_size.rs
+++ b/src/columns/vm_size.rs
@@ -32,13 +32,13 @@ impl Column for VmSize {
         _curr_io: &ProcResult<Io>,
         _prev_io: &ProcResult<Io>,
         _interval: &Duration,
-    ) -> () {
+    ) {
         let (size, unit) = unbytify::bytify(curr_proc.stat.vsize);
         let content = format!("{}{}", size, unit.replace("i", "").replace("B", ""));
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/columns/write_bytes.rs
+++ b/src/columns/write_bytes.rs
@@ -32,7 +32,7 @@ impl Column for WriteBytes {
         curr_io: &ProcResult<Io>,
         prev_io: &ProcResult<Io>,
         interval: &Duration,
-    ) -> () {
+    ) {
         let content = if curr_io.is_ok() && prev_io.is_ok() {
             let interval_ms = interval.as_secs() + interval.subsec_millis() as u64;
             let io = (curr_io.as_ref().unwrap().write_bytes
@@ -47,7 +47,7 @@ impl Column for WriteBytes {
 
         self.max_width = cmp::max(content.len(), self.max_width);
 
-        self.contents.insert(curr_proc.pid(), String::from(content));
+        self.contents.insert(curr_proc.pid(), content);
     }
 
     column_default!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,11 +180,8 @@ fn apply_style(x: String, cs: &ConfigColumnStyle, s: &ConfigStyle) -> StyledObje
 // ---------------------------------------------------------------------------------------------------------------------
 
 fn main() {
-    match run() {
-        Err(x) => {
-            eprintln!("{}", x);
-        }
-        _ => (),
+    if let Err(x) = run() {
+        eprintln!("{}", x);
     }
 }
 
@@ -246,7 +243,7 @@ fn collect_proc(cols: &mut Vec<ColumnInfo>, opt: &Opt) -> Vec<i32> {
     pids
 }
 
-fn display_header(max_width: usize, cols: &Vec<ColumnInfo>, config: &Config) -> () {
+fn display_header(max_width: usize, cols: &[ColumnInfo], config: &Config) {
     let mut row = String::from("");
     for c in cols.iter() {
         row = format!(
@@ -260,7 +257,7 @@ fn display_header(max_width: usize, cols: &Vec<ColumnInfo>, config: &Config) -> 
     println!("{}", row);
 }
 
-fn display_unit(max_width: usize, cols: &Vec<ColumnInfo>, config: &Config) -> () {
+fn display_unit(max_width: usize, cols: &[ColumnInfo], config: &Config) {
     let mut row = String::from("");
     for c in cols.iter() {
         row = format!(
@@ -274,7 +271,7 @@ fn display_unit(max_width: usize, cols: &Vec<ColumnInfo>, config: &Config) -> ()
     println!("{}", row);
 }
 
-fn display_item(pid: i32, max_width: usize, cols: &Vec<ColumnInfo>, config: &Config) -> () {
+fn display_item(pid: i32, max_width: usize, cols: &[ColumnInfo], config: &Config) {
     let mut row = String::from("");
     for c in cols.iter() {
         row = format!(


### PR DESCRIPTION
I took the liberty while looking through the code to clean up a bunch of (repetitive) clippy warnings.  Some of them might be personal style, like a preference for `fn foo (...) -> ()`, so feel free to cherry-pick as you wish.

There are still three examples (repeated) that remain:
 * all the static refs for the colour styles, clippys says should be YELLING
 * `interval.subsec_millis() as u64` complains that the cast could become lossy if the return type ever changes, and suggests `u64::from(..) instead. I'm not super keen on this one in this case, might be one to just `#[allow()]` instead
 * passing arg `columns: &[&Box<Column>]` which it suggest to just be `&[&Column]`, but that needs changes at the call sites too for dyn trait.
