### PR TITLE
Remove sudo from brew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ sudo snap install procs
 You can install from [homebrew](https://formulae.brew.sh/formula/procs)
 
 ```
-sudo brew install procs
+brew install procs
 ```
 
 ### Alpine Linux


### PR DESCRIPTION
homebrew packages should never be installed with sudo

https://docs.brew.sh/FAQ#why-does-homebrew-say-sudo-is-bad