### PR TITLE
Clear the screen on watch exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -705,6 +705,7 @@ fn run_watch(opt: &Opt, config: &Config, interval: u64) -> Result<(), Error> {
             thread::sleep(Duration::from_millis(100));
 
             if rx.try_recv().is_ok() {
+                term_info.term.clear_screen()?;
                 break 'outer;
             }
         }


### PR DESCRIPTION
Before this commit, exiting a watch would leave the contents of the
previous screen in your terminal for your shell prompt to write over.
This commit clears the screen when you exit watch gracefully instead.

Fixes #32