### PR TITLE
chore: update which from 3 to 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,6 +1247,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,12 +1598,12 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "which"
-version = "3.1.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
 dependencies = [
- "failure",
  "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,14 +54,14 @@ unicode-width = "0.1"
 pager         = "0.15"
 procfs        = "0.7.1"
 users         = "0.10"
-which         = "3"
+which         = "4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 libproc       = "0.5"
 errno         = "0.2"
 pager         = "0.15"
 users         = "0.10"
-which         = "3"
+which         = "4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi        = { version = "0.3", features = ["handleapi", "minwindef", "psapi", "securitybaseapi", "tlhelp32", "winbase", "winnt"] }


### PR DESCRIPTION
Bumping the dependendy from `which` 3 to 4 doesn't requrie code changes. `which` moved from `failure` to `thiserror`, which explains the new entries for the `thiserror` crates in `Cargo.lock`. Running tests was successful locally on my system (fedora 32).