### PR TITLE
remove VmPeak column from large.toml

### DIFF
--- a/config/large.toml
+++ b/config/large.toml
@@ -55,13 +55,6 @@ nonnumeric_search = false
 align = "Right"
 
 [[columns]]
-kind = "VmPeak"
-style = "ByUnit"
-numeric_search = false
-nonnumeric_search = false
-align = "Right"
-
-[[columns]]
 kind = "VmSize"
 style = "ByUnit"
 numeric_search = false


### PR DESCRIPTION
fixes a parse error with the latest version of procs that is thrown because of this:

```
error: failed to parse toml ("/Users/jasonkurian/.procs.toml")
  caused by: unknown variant `VmPeak`, expected one of `Command`, `ContextSw`, `CpuTime`, `Docker`, `Empty`, `Gid`, `GidReal`, `GidSaved`, `Group`, `GroupReal`, `GroupSaved`, `MajFlt`, `MinFlt`, `Nice`, `Pid`, `Policy`, `Ppid`, `Priority`, `ReadBytes`, `Separator`, `Slot`, `StartTime`, `State`, `TcpPort`, `Threads`, `Tree`, `Tty`, `UdpPort`, `Uid`, `UidReal`, `UidSaved`, `UsageCpu`, `UsageMem`, `User`, `UserReal`, `UserSaved`, `Username`, `VmRss`, `VmSize`, `WriteBytes` for key `columns.kind` at line 212 column 1
```

Thank you for this library! It's awesome! 💪🏽 