### PR TITLE
Add instructions about installation for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ The correct repository (see above link for the most up-to-date information) shou
 sudo apk add procs
 ```
 
+### Arch Linux
+
+You can install from [Arch Linux community repository](https://archlinux.org/packages/community/x86_64/procs/)
+
+```
+sudo pacman -S procs
+```
+
 ### Scoop
 
 You can install by [scoop](https://scoop.sh/)


### PR DESCRIPTION
`procs` is now available in the Arch Linux community repository: https://archlinux.org/packages/community/x86_64/procs/