### PR TITLE
Add: Add support for floating point values in watch interval

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ pub struct Opt {
 
     /// Watch mode with custom interval
     #[structopt(short = "W", long = "watch-interval", value_name = "second")]
-    pub watch_interval: Option<u64>,
+    pub watch_interval: Option<f64>,
 
     #[structopt(skip)]
     pub watch_mode: bool,
@@ -279,9 +279,11 @@ fn run() -> Result<(), Error> {
         return Ok(());
     } else {
         let config = get_config()?;
-
         if opt.watch_mode {
-            let interval = opt.watch_interval.unwrap_or(1);
+            let interval = match opt.watch_interval {
+                Some(n) => (n * 1000.0).round() as u64,
+                None=> 1000,
+            };
             run_watch(&opt, &config, interval)
         } else {
             run_default(&opt, &config)

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -63,7 +63,7 @@ impl Watcher {
             if let Ok(Command::Quit) = rx.recv() {
                 break;
             }
-            thread::sleep(Duration::from_secs(interval));
+            thread::sleep(Duration::from_millis(interval));
             let _ = tx.send(Command::Wake);
         });
     }
@@ -71,13 +71,13 @@ impl Watcher {
     fn display_header(term_info: &mut TermInfo, opt: &Opt, interval: u64) -> Result<(), Error> {
         let header = if opt.tree {
             format!(
-                " Interval: {}s, Last Updated: {} ( Quit: q or Ctrl-C )",
+                " Interval: {}ms, Last Updated: {} ( Quit: q or Ctrl-C )",
                 interval,
                 Local::now().format("%Y/%m/%d %H:%M:%S"),
             )
         } else {
             format!(
-                " Interval: {}s, Last Updated: {} ( Next: n, Prev: p, Ascending: a, Descending: d, Quit: q or Ctrl-C )",
+                " Interval: {}ms, Last Updated: {} ( Next: n, Prev: p, Ascending: a, Descending: d, Quit: q or Ctrl-C )",
                 interval,
                 Local::now().format("%Y/%m/%d %H:%M:%S"),
             )


### PR DESCRIPTION
In order to use interval less than 1 second, the interval value can
now be set as floating point value. The argument is still expressed
as seconds, so to use a 1 seconds interval, one must still use `-W 1`.