### PR TITLE
Remove Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: rust
-
-os:
-- osx
-
-script:
-- make test

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 **procs** is a replacement for `ps` written in [Rust](https://www.rust-lang.org/).
 
 [![Actions Status](https://github.com/dalance/procs/workflows/Regression/badge.svg)](https://github.com/dalance/procs/actions)
-[![Build Status](https://travis-ci.org/dalance/procs.svg?branch=master)](https://travis-ci.org/dalance/procs)
 [![codecov](https://codecov.io/gh/dalance/procs/branch/master/graph/badge.svg)](https://codecov.io/gh/dalance/procs)
 
 [![Changelog](https://img.shields.io/badge/changelog-v0.11.10-green.svg)](https://github.com/dalance/procs/blob/master/CHANGELOG.md)


### PR DESCRIPTION
On the basis that https://app.travis-ci.com/github/dalance/procs isn't active and there's a more detailed Github actions config, I'm assuming the Travis config isn't needed anymore?