### PR TITLE
Fix the location of the config file on macOS

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -78,7 +78,8 @@ macro_rules! column_default_display_content {
             pid: i32,
             align: &crate::config::ConfigColumnAlign,
         ) -> Option<String> {
-            self.fmt_contents.get(&pid)
+            self.fmt_contents
+                .get(&pid)
                 .map(|content| crate::util::adjust(content, self.width, align))
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,7 @@ fn get_config() -> Result<Config, Error> {
         .map(|base| base.home_dir().join(".procs.toml"))
         .filter(|path| path.exists());
     let app_cfg_path = directories::ProjectDirs::from("com.github", "dalance", "procs")
-        .map(|proj| proj.config_dir().join("config.toml"))
+        .map(|proj| proj.preference_dir().join("config.toml"))
         .filter(|path| path.exists());
     let xdg_cfg_path = directories::BaseDirs::new()
         .map(|base| {
@@ -282,7 +282,7 @@ fn run() -> Result<(), Error> {
         if opt.watch_mode {
             let interval = match opt.watch_interval {
                 Some(n) => (n * 1000.0).round() as u64,
-                None=> 1000,
+                None => 1000,
             };
             run_watch(&opt, &config, interval)
         } else {


### PR DESCRIPTION
Since v3.0.0 of `directories`, the behavior of `ProjectDirs::config_dir()` on macOS has been adjusted (see dirs-dev/directories-rs#62).
So I change this to use `ProjectDirs::preference_dir()` for compatibility.