### PR TITLE
Fix the issue links in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ## [v0.11.11](https://github.com/dalance/procs/compare/v0.11.10...v0.11.11) - 2021-12-14
 
-* [Fixed] panic when stdout is closed [#210](https://github.com/dalance/procs/issue/210)
+* [Fixed] panic when stdout is closed [#210](https://github.com/dalance/procs/issues/210)
 
 ## [v0.11.10](https://github.com/dalance/procs/compare/v0.11.9...v0.11.10) - 2021-10-19
 
 * [Added] pgid/session column [#150](https://github.com/dalance/procs/pull/150)
 * [Added] floating point watch interval support [#157](https://github.com/dalance/procs/pull/157)
-* [Added] MultiSlot column [#180](https://github.com/dalance/procs/issue/180)
-* [Fixed] Search failure with only option [#117](https://github.com/dalance/procs/issue/117)
-* [Added] Show children processes at tree mode [#181](https://github.com/dalance/procs/issue/181)
+* [Added] MultiSlot column [#180](https://github.com/dalance/procs/issues/180)
+* [Fixed] Search failure with only option [#117](https://github.com/dalance/procs/issues/117)
+* [Added] Show children processes at tree mode [#181](https://github.com/dalance/procs/issues/181)
 
 ## [v0.11.9](https://github.com/dalance/procs/compare/v0.11.8...v0.11.9) - 2021-06-22
 


### PR DESCRIPTION
Hello!

While I was looking at the changelog for the latest release, I realized some of the issue links were not correct, thus returning 404. e.g:

```diff
-https://github.com/dalance/procs/issue/210
+https://github.com/dalance/procs/issues/210
```

This is a humble PR that updates CHANGELOG.md to fix this :bear:

