### PR TITLE
Update tests to replace the deprecated usage of clap

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -373,7 +373,7 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
     }
@@ -385,39 +385,39 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs", "root"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "1"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--or", "root", "1"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--and", "root", "1"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--nor", "root", "1"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--nand", "root", "1"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
 
         config.search.nonnumeric_search = ConfigSearchKind::Exact;
         config.search.numeric_search = ConfigSearchKind::Partial;
         let args = vec!["procs", "root", "1"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
     }
@@ -441,7 +441,7 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         config.pager.mode = ConfigPagerMode::Disable;
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
@@ -454,7 +454,7 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs", "--insert", "ppid"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
     }
@@ -466,12 +466,12 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs", "--sorta", "cpu"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--sortd", "cpu"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
     }
@@ -483,7 +483,7 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs", "--tree"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
     }
@@ -498,7 +498,7 @@ mod tests {
         let _udp = std::net::UdpSocket::bind("127.0.0.1:10000");
 
         let args = vec!["procs"];
-        let opt = Opt::from_iter(args.iter());
+        let opt = Opt::parse_from(args.iter());
         let ret = run_default(&opt, &config);
         assert!(ret.is_ok());
     }


### PR DESCRIPTION
While running the tests, there are bunch of warnings about the deprecation of [`StructOpt::from_iter`](https://docs.rs/clap/3.0.8/clap/trait.Parser.html#method.from_iter):


```
warning: use of deprecated associated function `clap::Parser::from_iter`: `StructOpt::from_iter` is replaced with `Parser::parse_from` (note the change in derives)
   --> src/main.rs:388:24
    |
388 |         let opt = Opt::from_iter(args.iter());
    |                        ^^^^^^^^^

warning: use of deprecated associated function `clap::Parser::from_iter`: `StructOpt::from_iter` is replaced with `Parser::parse_from` (note the change in derives)
   --> src/main.rs:393:24
    |
393 |         let opt = Opt::from_iter(args.iter());
    |                        ^^^^^^^^^

warning: use of deprecated associated function `clap::Parser::from_iter`: `StructOpt::from_iter` is replaced with `Parser::parse_from` (note the change in derives)
   --> src/main.rs:398:24
    |
398 |         let opt = Opt::from_iter(args.iter());
    |                        ^^^^^^^^^
[...]
```

This PR simply applies the compiler suggestion.
