### PR TITLE
Update Makefile to change release zip names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,11 +22,11 @@ clean:
 
 release_lnx:
 	cargo build --locked --release --target=x86_64-unknown-linux-musl
-	zip -j ${BIN_NAME}-v${VERSION}-x86_64-lnx.zip target/x86_64-unknown-linux-musl/release/${BIN_NAME}
+	zip -j ${BIN_NAME}-v${VERSION}-x86_64-linux.zip target/x86_64-unknown-linux-musl/release/${BIN_NAME}
 
 release_win:
 	cargo build --locked --release --target=x86_64-pc-windows-msvc
-	7z a ${BIN_NAME}-v${VERSION}-x86_64-win.zip target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe
+	7z a ${BIN_NAME}-v${VERSION}-x86_64-windows.zip target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe
 
 release_mac:
 	cargo build --locked --release --target=x86_64-apple-darwin


### PR DESCRIPTION
So that tools like https://github.com/zyedidia/eget can be used to download the latest release easily.