### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/columns/usage_mem.rs
+++ b/src/columns/usage_mem.rs
@@ -65,16 +65,16 @@ fn get_mem_total() -> u64 {
 
 #[cfg(target_os = "windows")]
 fn get_mem_total() -> u64 {
-    unsafe {
-        let mut info: PERFORMANCE_INFORMATION = zeroed();
-        let ret = GetPerformanceInfo(&mut info, size_of::<PERFORMANCE_INFORMATION>() as u32);
+    
+        let mut info: PERFORMANCE_INFORMATION = unsafe { zeroed() };
+        let ret = unsafe { GetPerformanceInfo(&mut info, size_of::<PERFORMANCE_INFORMATION>() as u32) };
 
         if ret != 0 {
             info.PhysicalTotal as u64 * info.PageSize as u64
         } else {
             0
         }
-    }
+    
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
I think the scope of the unsafe block needs to be as small as possible, and there are fewer areas to focus on when reviewing unsafe-related errors.