### PR TITLE
release_win: pack exe in toplevel of zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/dalance/procs/compare/v0.13.2...Unreleased) - ReleaseDate
 
+* [Changed] Release zip for Windows has the exe at toplevel
+
 ## [v0.13.2](https://github.com/dalance/procs/compare/v0.13.1...v0.13.2) - 2022-10-05
 
 * [Fixed] invalid charset name issue [#366](https://github.com/dalance/procs/issues/366)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ release_lnx:
 
 release_win:
 	cargo build --locked --release --target=x86_64-pc-windows-msvc
-	7z a ${BIN_NAME}-v${VERSION}-x86_64-windows.zip target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe
+	mv -v target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe ./
+	7z a ${BIN_NAME}-v${VERSION}-x86_64-windows.zip ${BIN_NAME}.exe
 
 release_mac:
 	cargo build --locked --release --target=x86_64-apple-darwin


### PR DESCRIPTION
hello, we come from chshersh/tool-sync#85. We found that the windows zip has more directory inside than other platforms

```text
❯ 〉unzip -l procs-v0.13.2-x86_64-mac.zip
Archive:  procs-v0.13.2-x86_64-mac.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
  4172488  10-05-2022 09:55   procs
---------                     -------
  4172488                     1 file
❯ 〉unzip -l procs-v0.13.2-x86_64-linux.zip
Archive:  procs-v0.13.2-x86_64-linux.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
  5975784  10-05-2022 09:52   procs
---------                     -------
  5975784                     1 file
❯ 〉unzip -l procs-v0.13.2-x86_64-windows.zip
Archive:  procs-v0.13.2-x86_64-windows.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
  2173440  10-05-2022 02:53   target/x86_64-pc-windows-msvc/release/procs.exe
```

i opted to move the binary before zipping, rather than trying to work `zip` into the action. i'm not sure how to test this action though.

if you find this acceptable, please consider labeling with `hacktoberfest-accepted` as well. Thanks in advance!