### PR TITLE
adding sort column to inserts (closes #227)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -367,7 +367,7 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
@@ -379,39 +379,39 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs", "root"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "1"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--or", "root", "1"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--and", "root", "1"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--nor", "root", "1"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--nand", "root", "1"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         config.search.nonnumeric_search = ConfigSearchKind::Exact;
         config.search.numeric_search = ConfigSearchKind::Partial;
         let args = vec!["procs", "root", "1"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
@@ -435,7 +435,7 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         config.pager.mode = ConfigPagerMode::Disable;
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
@@ -448,7 +448,7 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs", "--insert", "ppid"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
@@ -460,12 +460,12 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs", "--sorta", "cpu"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--sortd", "cpu"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
@@ -477,7 +477,7 @@ mod tests {
         config.display.theme = ConfigTheme::Dark;
 
         let args = vec!["procs", "--tree"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
@@ -492,7 +492,7 @@ mod tests {
         let _udp = std::net::UdpSocket::bind("127.0.0.1:10000");
 
         let args = vec!["procs"];
-        let opt = Opt::parse_from(args.iter());
+        let mut opt = Opt::parse_from(args.iter());
         let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -281,9 +281,9 @@ fn run() -> Result<(), Error> {
                 Some(n) => (n * 1000.0).round() as u64,
                 None => 1000,
             };
-            run_watch(&opt, &config, interval)
+            run_watch(&mut opt, &config, interval)
         } else {
-            run_default(&opt, &config)
+            run_default(&mut opt, &config)
         }
     }
 }
@@ -320,11 +320,11 @@ fn run_list() -> Result<(), Error> {
 }
 
 #[cfg_attr(tarpaulin, skip)]
-fn run_watch(opt: &Opt, config: &Config, interval: u64) -> Result<(), Error> {
+fn run_watch(opt: &mut Opt, config: &Config, interval: u64) -> Result<(), Error> {
     Watcher::start(opt, config, interval)
 }
 
-fn run_default(opt: &Opt, config: &Config) -> Result<(), Error> {
+fn run_default(opt: &mut Opt, config: &Config) -> Result<(), Error> {
     let mut time = Instant::now();
 
     let theme = get_theme(opt, config);
@@ -368,7 +368,7 @@ mod tests {
 
         let args = vec!["procs"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
 
@@ -380,39 +380,39 @@ mod tests {
 
         let args = vec!["procs", "root"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "1"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--or", "root", "1"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--and", "root", "1"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--nor", "root", "1"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--nand", "root", "1"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         config.search.nonnumeric_search = ConfigSearchKind::Exact;
         config.search.numeric_search = ConfigSearchKind::Partial;
         let args = vec!["procs", "root", "1"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
 
@@ -437,7 +437,7 @@ mod tests {
         let args = vec!["procs"];
         let opt = Opt::parse_from(args.iter());
         config.pager.mode = ConfigPagerMode::Disable;
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
 
@@ -449,7 +449,7 @@ mod tests {
 
         let args = vec!["procs", "--insert", "ppid"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
 
@@ -461,12 +461,12 @@ mod tests {
 
         let args = vec!["procs", "--sorta", "cpu"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
 
         let args = vec!["procs", "--sortd", "cpu"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
 
@@ -478,7 +478,7 @@ mod tests {
 
         let args = vec!["procs", "--tree"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
 
@@ -493,7 +493,7 @@ mod tests {
 
         let args = vec!["procs"];
         let opt = Opt::parse_from(args.iter());
-        let ret = run_default(&opt, &config);
+        let ret = run_default(&mut opt, &config);
         assert!(ret.is_ok());
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -31,7 +31,7 @@ pub struct View {
 }
 
 impl View {
-    pub fn new(opt: &Opt, config: &Config, clear_by_line: bool) -> Result<Self, Error> {
+    pub fn new(opt: &mut Opt, config: &Config, clear_by_line: bool) -> Result<Self, Error> {
         let mut slot_idx = 0;
         let mut columns = Vec::new();
         let mut only_kind_found = false;
@@ -47,6 +47,16 @@ impl View {
             min_width: None,
             header: None,
         };
+
+        // Adding the sort column to inserts if not already present
+        match (&opt.sorta, &opt.sortd) {
+            (_, Some(col)) | (Some(col), _) => {
+                if !opt.insert.contains(&col) {
+                    opt.insert.push(col.clone());
+                }
+            }
+            _ => {}
+        }
 
         // Add default TreeSlot if there is not TreeSlot in config
         let config_columns = if config

--- a/src/view.rs
+++ b/src/view.rs
@@ -51,7 +51,7 @@ impl View {
         // Adding the sort column to inserts if not already present
         match (&opt.sorta, &opt.sortd) {
             (_, Some(col)) | (Some(col), _) => {
-                if !opt.insert.contains(&col) {
+                if !opt.insert.contains(col) {
                     opt.insert.push(col.clone());
                 }
             }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -91,7 +91,7 @@ impl Watcher {
         Ok(())
     }
 
-    pub fn start(opt: &Opt, config: &Config, interval: u64) -> Result<(), Error> {
+    pub fn start(opt: &mut Opt, config: &Config, interval: u64) -> Result<(), Error> {
         let theme = get_theme(opt, config);
 
         let (tx_cmd, rx_cmd) = channel();


### PR DESCRIPTION
This closes #227.

2 things:
- by default the sort column is pushed to the end of the inserts. Not sure if this is the best way to do it?
- since the insert names don't have to be exact. There would be situations like `procs --insert rss --sorta VmRss` that would create duplicate columns. Not sure if this is a concern in practice?