### PR TITLE
docker: Respect $DOCKER_HOST

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -619,7 +619,8 @@ pub struct ConfigDocker {
 impl Default for ConfigDocker {
     fn default() -> Self {
         ConfigDocker {
-            path: String::from("unix:///var/run/docker.sock"),
+            path: std::env::var("DOCKER_HOST")
+                .unwrap_or(String::from("unix:///var/run/docker.sock")),
         }
     }
 }


### PR DESCRIPTION
The existing path is the default/fallback (and usually the correct one when running docker as root). This environment variable is what docker will use if it is defined, and is usually defined when running docker rootless (or podman, or some other drop-in replacement).

Fixes: https://github.com/dalance/procs/issues/423