### PR TITLE
Feature/kthreads

### DIFF
--- a/src/columns/command.rs
+++ b/src/columns/command.rs
@@ -42,7 +42,7 @@ impl Column for Command {
                 cmd = cmd.replace(['\n', '\t'], " ");
                 cmd
             } else {
-                proc.curr_proc.stat().comm.clone()
+                format!("[{}]", proc.curr_proc.stat().comm)
             }
         } else {
             proc.curr_proc.stat().comm.clone()

--- a/src/config.rs
+++ b/src/config.rs
@@ -555,6 +555,8 @@ pub struct ConfigDisplay {
     pub abbr_sid: bool,
     #[serde(default = "default_theme_auto")]
     pub theme: ConfigTheme,
+    #[serde(default = "default_true")]
+    pub show_kthreads: bool,
 }
 
 impl Default for ConfigDisplay {
@@ -583,6 +585,7 @@ impl Default for ConfigDisplay {
             ],
             abbr_sid: true,
             theme: ConfigTheme::Auto,
+            show_kthreads: true,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,6 +186,10 @@ pub struct Opt {
     /// Show debug message
     #[clap(action, long = "debug", hide = true)]
     pub debug: bool,
+
+    /// Do not show kernel threads (Linux only)
+    #[clap(action, long="no-kthreads")]
+    pub no_kthreads: bool,
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,7 @@ pub struct Opt {
     pub debug: bool,
 
     /// Do not show kernel threads (Linux only)
-    #[clap(action, long="no-kthreads")]
+    #[clap(action, long = "no-kthreads")]
     pub no_kthreads: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,10 +186,6 @@ pub struct Opt {
     /// Show debug message
     #[clap(action, long = "debug", hide = true)]
     pub debug: bool,
-
-    /// Do not show kernel threads (Linux only)
-    #[clap(action, long = "no-kthreads")]
-    pub no_kthreads: bool,
 }
 
 // ---------------------------------------------------------------------------------------------------------------------

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -81,7 +81,7 @@ pub struct ProcessInfo {
     pub interval: Duration,
 }
 
-pub fn collect_proc(interval: Duration, with_thread: bool) -> Vec<ProcessInfo> {
+pub fn collect_proc(interval: Duration, with_thread: bool, without_kthread: bool) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut base_tasks = HashMap::new();
     let mut ret = Vec::new();
@@ -127,6 +127,12 @@ pub fn collect_proc(interval: Duration, with_thread: bool) -> Vec<ProcessInfo> {
         let curr_time = Instant::now();
         let interval = curr_time - prev_time;
         let ppid = curr_stat.ppid;
+
+        if without_kthread {
+            if ppid == 2 || pid == 2 {
+                continue;
+            }
+        }
 
         let mut curr_tasks = HashMap::new();
         if with_thread {

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -84,7 +84,7 @@ pub struct ProcessInfo {
 pub fn collect_proc(
     interval: Duration,
     with_thread: bool,
-    without_kthread: bool,
+    show_kthreads: bool,
 ) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut base_tasks = HashMap::new();
@@ -132,7 +132,7 @@ pub fn collect_proc(
         let interval = curr_time - prev_time;
         let ppid = curr_stat.ppid;
 
-        if without_kthread && (ppid == 2 || pid == 2) {
+        if !show_kthreads && (ppid == 2 || pid == 2) {
             continue;
         }
 

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -128,10 +128,8 @@ pub fn collect_proc(interval: Duration, with_thread: bool, without_kthread: bool
         let interval = curr_time - prev_time;
         let ppid = curr_stat.ppid;
 
-        if without_kthread {
-            if ppid == 2 || pid == 2 {
-                continue;
-            }
+        if without_kthread && (ppid == 2 || pid == 2) {
+            continue;
         }
 
         let mut curr_tasks = HashMap::new();

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -81,7 +81,11 @@ pub struct ProcessInfo {
     pub interval: Duration,
 }
 
-pub fn collect_proc(interval: Duration, with_thread: bool, without_kthread: bool) -> Vec<ProcessInfo> {
+pub fn collect_proc(
+    interval: Duration,
+    with_thread: bool,
+    without_kthread: bool,
+) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut base_tasks = HashMap::new();
     let mut ret = Vec::new();

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -26,7 +26,7 @@ pub struct ProcessInfo {
 }
 
 #[cfg_attr(tarpaulin, skip)]
-pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> {
+pub fn collect_proc(interval: Duration, _with_thread: bool, _without_kthread: bool) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut ret = Vec::new();
     let arg_max = get_arg_max();

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -29,7 +29,7 @@ pub struct ProcessInfo {
 pub fn collect_proc(
     interval: Duration,
     _with_thread: bool,
-    _without_kthread: bool,
+    _show_kthreads: bool,
 ) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut ret = Vec::new();

--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -26,7 +26,11 @@ pub struct ProcessInfo {
 }
 
 #[cfg_attr(tarpaulin, skip)]
-pub fn collect_proc(interval: Duration, _with_thread: bool, _without_kthread: bool) -> Vec<ProcessInfo> {
+pub fn collect_proc(
+    interval: Duration,
+    _with_thread: bool,
+    _without_kthread: bool,
+) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut ret = Vec::new();
     let arg_max = get_arg_max();

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -70,7 +70,11 @@ pub struct CpuInfo {
 }
 
 #[cfg_attr(tarpaulin, skip)]
-pub fn collect_proc(interval: Duration, _with_thread: bool, _without_kthread: bool) -> Vec<ProcessInfo> {
+pub fn collect_proc(
+    interval: Duration,
+    _with_thread: bool,
+    _without_kthread: bool,
+) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut ret = Vec::new();
 

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -73,7 +73,7 @@ pub struct CpuInfo {
 pub fn collect_proc(
     interval: Duration,
     _with_thread: bool,
-    _without_kthread: bool,
+    _show_kthreads: bool,
 ) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut ret = Vec::new();

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -70,7 +70,7 @@ pub struct CpuInfo {
 }
 
 #[cfg_attr(tarpaulin, skip)]
-pub fn collect_proc(interval: Duration, _with_thread: bool) -> Vec<ProcessInfo> {
+pub fn collect_proc(interval: Duration, _with_thread: bool, _without_kthread: bool) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
     let mut ret = Vec::new();
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -171,7 +171,7 @@ impl View {
         let proc = collect_proc(
             Duration::from_millis(opt.interval),
             show_thread,
-            opt.no_kthreads,
+            config.display.show_kthreads,
         );
         for c in columns.iter_mut() {
             for p in &proc {

--- a/src/view.rs
+++ b/src/view.rs
@@ -168,7 +168,7 @@ impl View {
             config.display.show_thread
         };
 
-        let proc = collect_proc(Duration::from_millis(opt.interval), show_thread);
+        let proc = collect_proc(Duration::from_millis(opt.interval), show_thread, opt.no_kthreads);
         for c in columns.iter_mut() {
             for p in &proc {
                 c.column.add(p);

--- a/src/view.rs
+++ b/src/view.rs
@@ -168,7 +168,11 @@ impl View {
             config.display.show_thread
         };
 
-        let proc = collect_proc(Duration::from_millis(opt.interval), show_thread, opt.no_kthreads);
+        let proc = collect_proc(
+            Duration::from_millis(opt.interval),
+            show_thread,
+            opt.no_kthreads,
+        );
         for c in columns.iter_mut() {
             for p in &proc {
                 c.column.add(p);


### PR DESCRIPTION
I often need to remove kthreads from the output of top/ps commands, to only check what is running in userspace.
For this reason I would like an option to filter out them.
I also prefer to print them out surrounded by square brackets to easily eyeball them when not filtered out.