### PR TITLE
Also look for a config file in /etc/procs/procs.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,9 +227,9 @@ checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
 dependencies = [
  "bitflags 2.3.3",
  "cexpr",
@@ -1052,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "libproc"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fba61dbe003b79fe1af52ff15a489e50b9e66b36c79f945fbcbcf02e895f26d"
+checksum = "229004ebba9d1d5caf41623f1523b6d52abb47d9f6ab87f7e6fc992e3b854aef"
 dependencies = [
  "bindgen",
  "errno 0.3.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
 
 [[package]]
 name = "url"

--- a/README.md
+++ b/README.md
@@ -310,10 +310,10 @@ You can change configuration by writing a configuration file.
 There are some configuration examples in `config` directory of this repository.
 `config/large.toml` is the default configuration before procs v0.9.21.
 
-The location of the configuration file is OS-specific:
+The locations of the configuration file is OS-specific:
 
- * Linux: `~/.config/procs/config.toml`
- * macOS: `~/Library/Preferences/com.github.dalance.procs/config.toml`
+ * Linux: `~/.config/procs/config.toml`, `/etc/procs/procs.toml`
+ * macOS: `~/Library/Preferences/com.github.dalance.procs/config.toml`, `/etc/procs/procs.toml`
  * Windows: `~/AppData/Roaming/dalance/procs/config/config.toml`
 
 For compatibility, if `~/.procs.toml` exists, it will be preferred to

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,12 +208,16 @@ fn get_config(opt: &Opt) -> Result<Config, Error> {
                 .join("config.toml")
         })
         .filter(|path| path.exists());
+    let etc_cfg_path = match PathBuf::from("/etc/procs/procs.toml") {
+        etc_path => etc_path.exists().then(|| etc_path),
+    };
     let cfg_path = opt
         .load_config
         .clone()
         .or(dot_cfg_path)
         .or(app_cfg_path)
-        .or(xdg_cfg_path);
+        .or(xdg_cfg_path)
+        .or(etc_cfg_path);
 
     let config: Config = if let Some(path) = cfg_path {
         let mut f = fs::File::open(&path).context(format!("failed to open file ({path:?})"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,9 +208,8 @@ fn get_config(opt: &Opt) -> Result<Config, Error> {
                 .join("config.toml")
         })
         .filter(|path| path.exists());
-    let etc_cfg_path = match PathBuf::from("/etc/procs/procs.toml") {
-        etc_path => etc_path.exists().then_some(etc_path),
-    };
+    let etc_path = PathBuf::from("/etc/procs/procs.toml");
+    let etc_cfg_path = etc_path.exists().then_some(etc_path);
     let cfg_path = opt
         .load_config
         .clone()

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,7 @@ fn get_config(opt: &Opt) -> Result<Config, Error> {
         })
         .filter(|path| path.exists());
     let etc_cfg_path = match PathBuf::from("/etc/procs/procs.toml") {
-        etc_path => etc_path.exists().then(|| etc_path),
+        etc_path => etc_path.exists().then_some(etc_path),
     };
     let cfg_path = opt
         .load_config


### PR DESCRIPTION
Hi there! 
I'm currently [packaging procs for OpenWrt](https://github.com/openwrt/packages/pull/21505) . OpenWrt's grep is limited, so I had to disable the pager with a config file.
The tricky part is OpenWrt's default user is root with its home at /, which isn't ideal for dropping a config file. That's why I'm submitting this PR. It'll let procs check for a config in /etc/procs/procs.toml. This small tweak can make procs more flexible and easier to adopt for OpenWrt users.