### PR TITLE
clippy fixes

### DIFF
--- a/src/column.rs
+++ b/src/column.rs
@@ -125,7 +125,7 @@ macro_rules! column_default_sorted_pid {
         fn sorted_pid(&self, order: &$crate::config::ConfigSortOrder) -> Vec<i32> {
             let mut contents: Vec<(&i32, &$x)> = self.raw_contents.iter().collect();
             contents.sort_by_key(|&(_x, y)| y);
-            if let $crate::config::ConfigSortOrder::Descending = order {
+            if matches!(*order, $crate::config::ConfigSortOrder::Descending) {
                 contents.reverse()
             }
             contents.iter().map(|(x, _y)| **x).collect()

--- a/src/columns/ccgroup.rs
+++ b/src/columns/ccgroup.rs
@@ -23,7 +23,7 @@ impl Ccgroup {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Cgroup (compressed)"));
         let unit = String::new();
-        Ccgroup {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/cgroup.rs
+++ b/src/columns/cgroup.rs
@@ -15,7 +15,7 @@ impl Cgroup {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Cgroup"));
         let unit = String::new();
-        Cgroup {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/command.rs
+++ b/src/columns/command.rs
@@ -15,7 +15,7 @@ impl Command {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Command"));
         let unit = String::new();
-        Command {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/context_sw.rs
+++ b/src/columns/context_sw.rs
@@ -16,7 +16,7 @@ impl ContextSw {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("ContextSw"));
         let unit = String::new();
-        ContextSw {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/cpu_time.rs
+++ b/src/columns/cpu_time.rs
@@ -15,7 +15,7 @@ impl CpuTime {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("CPU Time"));
         let unit = String::new();
-        CpuTime {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/docker.rs
+++ b/src/columns/docker.rs
@@ -41,7 +41,7 @@ impl Docker {
         } else {
             available = false;
         }
-        Docker {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/eip.rs
+++ b/src/columns/eip.rs
@@ -15,7 +15,7 @@ impl Eip {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("EIP"));
         let unit = String::new();
-        Eip {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/elapsed_time.rs
+++ b/src/columns/elapsed_time.rs
@@ -27,7 +27,7 @@ impl ElapsedTime {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Elapsed"));
         let unit = String::new();
-        ElapsedTime {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/empty.rs
+++ b/src/columns/empty.rs
@@ -15,7 +15,7 @@ impl Empty {
     pub fn new() -> Self {
         let header = String::new();
         let unit = String::new();
-        Empty {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/env.rs
+++ b/src/columns/env.rs
@@ -15,7 +15,7 @@ impl Env {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Env"));
         let unit = String::new();
-        Env {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/esp.rs
+++ b/src/columns/esp.rs
@@ -15,7 +15,7 @@ impl Esp {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("ESP"));
         let unit = String::new();
-        Esp {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/file_name.rs
+++ b/src/columns/file_name.rs
@@ -15,7 +15,7 @@ impl FileName {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("FileName"));
         let unit = String::new();
-        FileName {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/gid.rs
+++ b/src/columns/gid.rs
@@ -19,7 +19,7 @@ impl Gid {
     pub fn new(header: Option<String>, abbr_sid: bool) -> Self {
         let header = header.unwrap_or_else(|| String::from("GID"));
         let unit = String::new();
-        Gid {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,
@@ -65,7 +65,7 @@ impl Column for Gid {
 impl Column for Gid {
     fn add(&mut self, proc: &ProcessInfo) {
         let mut sid = &proc.groups[0].sid;
-        let mut kind = std::u64::MAX;
+        let mut kind = u64::MAX;
         for g in &proc.groups {
             if g.sid.len() > 3 && g.sid[1] == 5 && g.sid[2] == 32 && kind > g.sid[3] {
                 sid = &g.sid;

--- a/src/columns/gid_fs.rs
+++ b/src/columns/gid_fs.rs
@@ -15,7 +15,7 @@ impl GidFs {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("FGID"));
         let unit = String::new();
-        GidFs {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/gid_real.rs
+++ b/src/columns/gid_real.rs
@@ -15,7 +15,7 @@ impl GidReal {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("RGID"));
         let unit = String::new();
-        GidReal {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/gid_saved.rs
+++ b/src/columns/gid_saved.rs
@@ -15,7 +15,7 @@ impl GidSaved {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("SGID"));
         let unit = String::new();
-        GidSaved {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/group.rs
+++ b/src/columns/group.rs
@@ -23,7 +23,7 @@ impl Group {
     pub fn new(header: Option<String>, abbr_sid: bool) -> Self {
         let header = header.unwrap_or_else(|| String::from("Group"));
         let unit = String::new();
-        Group {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,
@@ -79,7 +79,7 @@ impl Column for Group {
 impl Column for Group {
     fn add(&mut self, proc: &ProcessInfo) {
         let mut sid_name = &proc.groups[0];
-        let mut kind = std::u64::MAX;
+        let mut kind = u64::MAX;
         for g in &proc.groups {
             if g.sid.len() > 3 && g.sid[1] == 5 && g.sid[2] == 32 && kind > g.sid[3] {
                 sid_name = g;

--- a/src/columns/group_fs.rs
+++ b/src/columns/group_fs.rs
@@ -17,7 +17,7 @@ impl GroupFs {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("File System Group"));
         let unit = String::new();
-        GroupFs {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/group_real.rs
+++ b/src/columns/group_real.rs
@@ -17,7 +17,7 @@ impl GroupReal {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Real Group"));
         let unit = String::new();
-        GroupReal {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/group_saved.rs
+++ b/src/columns/group_saved.rs
@@ -17,7 +17,7 @@ impl GroupSaved {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Saved Group"));
         let unit = String::new();
-        GroupSaved {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/maj_flt.rs
+++ b/src/columns/maj_flt.rs
@@ -15,7 +15,7 @@ impl MajFlt {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("MajorFaults"));
         let unit = String::new();
-        MajFlt {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,
@@ -42,7 +42,7 @@ impl Column for MajFlt {
 impl Column for MajFlt {
     fn add(&mut self, proc: &ProcessInfo) {
         let raw_content = proc.curr_task.ptinfo.pti_pageins as u64;
-        let fmt_content = format!("{}", raw_content);
+        let fmt_content = format!("{raw_content}");
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);
@@ -55,7 +55,7 @@ impl Column for MajFlt {
 impl Column for MajFlt {
     fn add(&mut self, proc: &ProcessInfo) {
         let raw_content = proc.memory_info.page_fault_count;
-        let fmt_content = format!("{}", raw_content);
+        let fmt_content = format!("{raw_content}");
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);

--- a/src/columns/min_flt.rs
+++ b/src/columns/min_flt.rs
@@ -15,7 +15,7 @@ impl MinFlt {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("MinorFaults"));
         let unit = String::new();
-        MinFlt {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/multi_slot.rs
+++ b/src/columns/multi_slot.rs
@@ -15,7 +15,7 @@ impl MultiSlot {
     pub fn new() -> Self {
         let header = String::new();
         let unit = String::new();
-        MultiSlot {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/nice.rs
+++ b/src/columns/nice.rs
@@ -15,7 +15,7 @@ impl Nice {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Nice"));
         let unit = String::new();
-        Nice {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/pgid.rs
+++ b/src/columns/pgid.rs
@@ -15,7 +15,7 @@ impl Pgid {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("PGID"));
         let unit = String::new();
-        Pgid {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/pid.rs
+++ b/src/columns/pid.rs
@@ -15,7 +15,7 @@ impl Pid {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("PID"));
         let unit = String::new();
-        Pid {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,
@@ -45,7 +45,7 @@ impl Column for Pid {
 impl Column for Pid {
     fn add(&mut self, proc: &ProcessInfo) {
         let raw_content = proc.pid;
-        let fmt_content = format!("{}", raw_content);
+        let fmt_content = format!("{raw_content}");
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);

--- a/src/columns/policy.rs
+++ b/src/columns/policy.rs
@@ -15,7 +15,7 @@ impl Policy {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Policy"));
         let unit = String::new();
-        Policy {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/ppid.rs
+++ b/src/columns/ppid.rs
@@ -15,7 +15,7 @@ impl Ppid {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Parent PID"));
         let unit = String::new();
-        Ppid {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/priority.rs
+++ b/src/columns/priority.rs
@@ -15,7 +15,7 @@ impl Priority {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Priority"));
         let unit = String::new();
-        Priority {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/processor.rs
+++ b/src/columns/processor.rs
@@ -15,7 +15,7 @@ impl Processor {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Processor"));
         let unit = String::new();
-        Processor {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/read_bytes.rs
+++ b/src/columns/read_bytes.rs
@@ -16,7 +16,7 @@ impl ReadBytes {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Read"));
         let unit = String::from("[B/s]");
-        ReadBytes {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/rt_priority.rs
+++ b/src/columns/rt_priority.rs
@@ -15,7 +15,7 @@ impl RtPriority {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("RT Priority"));
         let unit = String::new();
-        RtPriority {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/sec_context.rs
+++ b/src/columns/sec_context.rs
@@ -17,7 +17,7 @@ impl SecContext {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Context"));
         let unit = String::new();
-        SecContext {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/separator.rs
+++ b/src/columns/separator.rs
@@ -16,7 +16,7 @@ impl Separator {
     pub fn new(separator: &str) -> Self {
         let header = String::from(separator);
         let unit = String::from(separator);
-        Separator {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/session.rs
+++ b/src/columns/session.rs
@@ -17,7 +17,7 @@ impl Session {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Session"));
         let unit = String::new();
-        Session {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/shd_pnd.rs
+++ b/src/columns/shd_pnd.rs
@@ -15,7 +15,7 @@ impl ShdPnd {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("ShdPnd"));
         let unit = String::new();
-        ShdPnd {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/sig_blk.rs
+++ b/src/columns/sig_blk.rs
@@ -15,7 +15,7 @@ impl SigBlk {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("SigBlk"));
         let unit = String::new();
-        SigBlk {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/sig_cgt.rs
+++ b/src/columns/sig_cgt.rs
@@ -15,7 +15,7 @@ impl SigCgt {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("SigCgt"));
         let unit = String::new();
-        SigCgt {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/sig_ign.rs
+++ b/src/columns/sig_ign.rs
@@ -15,7 +15,7 @@ impl SigIgn {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("SigIgn"));
         let unit = String::new();
-        SigIgn {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/sig_pnd.rs
+++ b/src/columns/sig_pnd.rs
@@ -15,7 +15,7 @@ impl SigPnd {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("SigPnd"));
         let unit = String::new();
-        SigPnd {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/slot.rs
+++ b/src/columns/slot.rs
@@ -15,7 +15,7 @@ impl Slot {
     pub fn new() -> Self {
         let header = String::new();
         let unit = String::new();
-        Slot {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/ssb.rs
+++ b/src/columns/ssb.rs
@@ -15,7 +15,7 @@ impl Ssb {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Speculative Store Bypass"));
         let unit = String::new();
-        Ssb {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/start_time.rs
+++ b/src/columns/start_time.rs
@@ -27,7 +27,7 @@ impl StartTime {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Start"));
         let unit = String::new();
-        StartTime {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/state.rs
+++ b/src/columns/state.rs
@@ -15,7 +15,7 @@ impl State {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("State"));
         let unit = String::new();
-        State {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/tcp_port.rs
+++ b/src/columns/tcp_port.rs
@@ -33,7 +33,7 @@ impl TcpPort {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("TCP"));
         let unit = String::new();
-        TcpPort {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/threads.rs
+++ b/src/columns/threads.rs
@@ -15,7 +15,7 @@ impl Threads {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Threads"));
         let unit = String::new();
-        Threads {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/tree.rs
+++ b/src/columns/tree.rs
@@ -16,7 +16,7 @@ impl Tree {
     pub fn new(symbols: &[String; 5]) -> Self {
         let header = String::new();
         let unit = String::new();
-        Tree {
+        Self {
             width: 0,
             header,
             unit,

--- a/src/columns/tree_slot.rs
+++ b/src/columns/tree_slot.rs
@@ -15,7 +15,7 @@ impl TreeSlot {
     pub fn new() -> Self {
         let header = String::new();
         let unit = String::new();
-        TreeSlot {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/tty.rs
+++ b/src/columns/tty.rs
@@ -15,7 +15,7 @@ impl Tty {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("TTY"));
         let unit = String::new();
-        Tty {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/udp_port.rs
+++ b/src/columns/udp_port.rs
@@ -23,7 +23,7 @@ impl UdpPort {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("UDP"));
         let unit = String::new();
-        UdpPort {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/uid.rs
+++ b/src/columns/uid.rs
@@ -19,7 +19,7 @@ impl Uid {
     pub fn new(header: Option<String>, abbr_sid: bool) -> Self {
         let header = header.unwrap_or_else(|| String::from("UID"));
         let unit = String::new();
-        Uid {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/uid_fs.rs
+++ b/src/columns/uid_fs.rs
@@ -15,7 +15,7 @@ impl UidFs {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("FUID"));
         let unit = String::new();
-        UidFs {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/uid_login.rs
+++ b/src/columns/uid_login.rs
@@ -17,7 +17,7 @@ impl UidLogin {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("LoginUID"));
         let unit = String::new();
-        UidLogin {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/uid_real.rs
+++ b/src/columns/uid_real.rs
@@ -15,7 +15,7 @@ impl UidReal {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("RUID"));
         let unit = String::new();
-        UidReal {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/uid_saved.rs
+++ b/src/columns/uid_saved.rs
@@ -15,7 +15,7 @@ impl UidSaved {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("SUID"));
         let unit = String::new();
-        UidSaved {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/usage_cpu.rs
+++ b/src/columns/usage_cpu.rs
@@ -15,7 +15,7 @@ impl UsageCpu {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("CPU"));
         let unit = String::from("[%]");
-        UsageCpu {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/usage_mem.rs
+++ b/src/columns/usage_mem.rs
@@ -23,7 +23,7 @@ impl UsageMem {
         let header = header.unwrap_or_else(|| String::from("MEM"));
         let unit = String::from("[%]");
 
-        UsageMem {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/user.rs
+++ b/src/columns/user.rs
@@ -23,7 +23,7 @@ impl User {
     pub fn new(header: Option<String>, abbr_sid: bool) -> Self {
         let header = header.unwrap_or_else(|| String::from("User"));
         let unit = String::new();
-        User {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/user_fs.rs
+++ b/src/columns/user_fs.rs
@@ -17,7 +17,7 @@ impl UserFs {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("File System User"));
         let unit = String::new();
-        UserFs {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/user_login.rs
+++ b/src/columns/user_login.rs
@@ -19,7 +19,7 @@ impl UserLogin {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Login User"));
         let unit = String::new();
-        UserLogin {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/user_real.rs
+++ b/src/columns/user_real.rs
@@ -17,7 +17,7 @@ impl UserReal {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Real User"));
         let unit = String::new();
-        UserReal {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/user_saved.rs
+++ b/src/columns/user_saved.rs
@@ -17,7 +17,7 @@ impl UserSaved {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Saved User"));
         let unit = String::new();
-        UserSaved {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_data.rs
+++ b/src/columns/vm_data.rs
@@ -16,7 +16,7 @@ impl VmData {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmData"));
         let unit = String::from("[bytes]");
-        VmData {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_exe.rs
+++ b/src/columns/vm_exe.rs
@@ -16,7 +16,7 @@ impl VmExe {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmExe"));
         let unit = String::from("[bytes]");
-        VmExe {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_hwm.rs
+++ b/src/columns/vm_hwm.rs
@@ -16,7 +16,7 @@ impl VmHwm {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmHwm"));
         let unit = String::from("[bytes]");
-        VmHwm {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_lib.rs
+++ b/src/columns/vm_lib.rs
@@ -16,7 +16,7 @@ impl VmLib {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmLib"));
         let unit = String::from("[bytes]");
-        VmLib {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_lock.rs
+++ b/src/columns/vm_lock.rs
@@ -16,7 +16,7 @@ impl VmLock {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmLock"));
         let unit = String::from("[bytes]");
-        VmLock {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_peak.rs
+++ b/src/columns/vm_peak.rs
@@ -16,7 +16,7 @@ impl VmPeak {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmPeak"));
         let unit = String::from("[bytes]");
-        VmPeak {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_pin.rs
+++ b/src/columns/vm_pin.rs
@@ -16,7 +16,7 @@ impl VmPin {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmPin"));
         let unit = String::from("[bytes]");
-        VmPin {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_pte.rs
+++ b/src/columns/vm_pte.rs
@@ -16,7 +16,7 @@ impl VmPte {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmPte"));
         let unit = String::from("[bytes]");
-        VmPte {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_rss.rs
+++ b/src/columns/vm_rss.rs
@@ -16,7 +16,7 @@ impl VmRss {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmRSS"));
         let unit = String::from("[bytes]");
-        VmRss {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_size.rs
+++ b/src/columns/vm_size.rs
@@ -16,7 +16,7 @@ impl VmSize {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmSize"));
         let unit = String::from("[bytes]");
-        VmSize {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_stack.rs
+++ b/src/columns/vm_stack.rs
@@ -16,7 +16,7 @@ impl VmStack {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmStack"));
         let unit = String::from("[bytes]");
-        VmStack {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/vm_swap.rs
+++ b/src/columns/vm_swap.rs
@@ -16,7 +16,7 @@ impl VmSwap {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("VmSwap"));
         let unit = String::from("[bytes]");
-        VmSwap {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/wchan.rs
+++ b/src/columns/wchan.rs
@@ -15,7 +15,7 @@ impl Wchan {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Wchan"));
         let unit = String::new();
-        Wchan {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/work_dir.rs
+++ b/src/columns/work_dir.rs
@@ -15,7 +15,7 @@ impl WorkDir {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("WorkDir"));
         let unit = String::new();
-        WorkDir {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/columns/write_bytes.rs
+++ b/src/columns/write_bytes.rs
@@ -16,7 +16,7 @@ impl WriteBytes {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Write"));
         let unit = String::from("[B/s]");
-        WriteBytes {
+        Self {
             fmt_contents: HashMap::new(),
             raw_contents: HashMap::new(),
             width: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,8 @@ fn run() -> Result<(), Error> {
     if opt.gen_config {
         run_gen_config()
     } else if opt.list {
-        run_list()
+        run_list();
+        Ok(())
     } else if let Some(shell) = opt.gen_completion {
         //Opt::clap().gen_completions("procs", shell, "./");
         clap_complete::generate_to(shell, &mut Opt::command(), "procs", "./")?;
@@ -310,7 +311,7 @@ fn run_gen_config() -> Result<(), Error> {
     Ok(())
 }
 
-fn run_list() -> Result<(), Error> {
+fn run_list() {
     let mut width = 0;
     let mut list = Vec::new();
     let mut desc = HashMap::new();
@@ -328,8 +329,6 @@ fn run_list() -> Result<(), Error> {
             desc[l]
         );
     }
-
-    Ok(())
 }
 
 fn run_watch(opt: &mut Opt, config: &Config, interval: u64) -> Result<(), Error> {
@@ -431,12 +430,6 @@ mod tests {
     #[test]
     fn test_run_gen_config() {
         let ret = run_gen_config();
-        assert!(ret.is_ok());
-    }
-
-    #[test]
-    fn test_run_list() {
-        let ret = run_list();
         assert!(ret.is_ok());
     }
 

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -622,7 +622,7 @@ fn from_wide_ptr(ptr: *const u16) -> String {
     use std::os::windows::ffi::OsStringExt;
 
     assert!(!ptr.is_null());
-    let len = (0..std::isize::MAX)
+    let len = (0..isize::MAX)
         .position(|i| unsafe { *ptr.offset(i) == 0 })
         .unwrap();
     let slice = unsafe { std::slice::from_raw_parts(ptr, len) };

--- a/src/style.rs
+++ b/src/style.rs
@@ -26,16 +26,16 @@ fn apply_style_by_state(
     faded: bool,
 ) -> StyledObject<String> {
     match x {
-        ref x if x.contains('D') => apply_color(x.to_string(), &s.by_state.color_d, theme, faded),
-        ref x if x.contains('R') => apply_color(x.to_string(), &s.by_state.color_r, theme, faded),
-        ref x if x.contains('S') => apply_color(x.to_string(), &s.by_state.color_s, theme, faded),
-        ref x if x.contains('T') => apply_color(x.to_string(), &s.by_state.color_t, theme, faded),
-        ref x if x.contains('t') => apply_color(x.to_string(), &s.by_state.color_t, theme, faded),
-        ref x if x.contains('Z') => apply_color(x.to_string(), &s.by_state.color_z, theme, faded),
-        ref x if x.contains('X') => apply_color(x.to_string(), &s.by_state.color_x, theme, faded),
-        ref x if x.contains('K') => apply_color(x.to_string(), &s.by_state.color_k, theme, faded),
-        ref x if x.contains('W') => apply_color(x.to_string(), &s.by_state.color_w, theme, faded),
-        ref x if x.contains('P') => apply_color(x.to_string(), &s.by_state.color_p, theme, faded),
+        x if x.contains('D') => apply_color(x.to_string(), &s.by_state.color_d, theme, faded),
+        x if x.contains('R') => apply_color(x.to_string(), &s.by_state.color_r, theme, faded),
+        x if x.contains('S') => apply_color(x.to_string(), &s.by_state.color_s, theme, faded),
+        x if x.contains('T') => apply_color(x.to_string(), &s.by_state.color_t, theme, faded),
+        x if x.contains('t') => apply_color(x.to_string(), &s.by_state.color_t, theme, faded),
+        x if x.contains('Z') => apply_color(x.to_string(), &s.by_state.color_z, theme, faded),
+        x if x.contains('X') => apply_color(x.to_string(), &s.by_state.color_x, theme, faded),
+        x if x.contains('K') => apply_color(x.to_string(), &s.by_state.color_k, theme, faded),
+        x if x.contains('W') => apply_color(x.to_string(), &s.by_state.color_w, theme, faded),
+        x if x.contains('P') => apply_color(x.to_string(), &s.by_state.color_p, theme, faded),
         _ => apply_color(x, &s.by_state.color_x, theme, faded),
     }
 }
@@ -47,11 +47,11 @@ fn apply_style_by_unit(
     faded: bool,
 ) -> StyledObject<String> {
     match x {
-        ref x if x.contains('K') => apply_color(x.to_string(), &s.by_unit.color_k, theme, faded),
-        ref x if x.contains('M') => apply_color(x.to_string(), &s.by_unit.color_m, theme, faded),
-        ref x if x.contains('G') => apply_color(x.to_string(), &s.by_unit.color_g, theme, faded),
-        ref x if x.contains('T') => apply_color(x.to_string(), &s.by_unit.color_t, theme, faded),
-        ref x if x.contains('P') => apply_color(x.to_string(), &s.by_unit.color_p, theme, faded),
+        x if x.contains('K') => apply_color(x.to_string(), &s.by_unit.color_k, theme, faded),
+        x if x.contains('M') => apply_color(x.to_string(), &s.by_unit.color_m, theme, faded),
+        x if x.contains('G') => apply_color(x.to_string(), &s.by_unit.color_g, theme, faded),
+        x if x.contains('T') => apply_color(x.to_string(), &s.by_unit.color_t, theme, faded),
+        x if x.contains('P') => apply_color(x.to_string(), &s.by_unit.color_p, theme, faded),
         _ => apply_color(x, &s.by_unit.color_x, theme, faded),
     }
 }

--- a/src/view.rs
+++ b/src/view.rs
@@ -114,7 +114,7 @@ impl View {
             };
 
             for kind in kinds {
-                let visible = if let Some(ref only) = opt.only {
+                let visible = if let Some(only) = &opt.only {
                     let kind_name = KIND_LIST[&kind].0.to_lowercase();
                     if !kind_name.contains(&only.to_lowercase()) {
                         false
@@ -154,7 +154,7 @@ impl View {
             bail!("There is not enough slot for inserting columns {:?}.\nPlease add \"Slot\" or \"MultiSlot\" to your config.\nhttps://github.com/dalance/procs#insert-column", opt.insert);
         }
 
-        if let Some(ref only_kind) = opt.only {
+        if let Some(only_kind) = &opt.only {
             if !only_kind_found {
                 bail!("kind \"{}\" is not found in columns", only_kind);
             }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -67,7 +67,7 @@ impl Watcher {
         });
     }
 
-    fn display_header(term_info: &mut TermInfo, opt: &Opt, interval: u64) -> Result<(), Error> {
+    fn display_header(term_info: &TermInfo, opt: &Opt, interval: u64) -> Result<(), Error> {
         let header = if opt.tree {
             format!(
                 " Interval: {}ms, Last Updated: {} ( Quit: q or Ctrl-C )",
@@ -127,7 +127,7 @@ impl Watcher {
             if resized {
                 term_info.clear_screen()?;
             }
-            Watcher::display_header(&mut view.term_info, opt, interval)?;
+            Watcher::display_header(&view.term_info, opt, interval)?;
 
             view.display(opt, config, &theme)?;
 


### PR DESCRIPTION
I used clippy with very pedantic lints (including absolutely useless lints) which gave some hints about making code more idiomatic

<details><summary>cargo clippy command</summary>

```
cargo clippy --all -- \
          -W clippy::all \
          -W clippy::pedantic \
          -W clippy::restriction \
          -W clippy::nursery \
          -W clippy::cargo \
          -A clippy::modulo_arithmetic \
          -A clippy::arithmetic_side_effects \
          -A clippy::missing_inline_in_public_items \
          -A clippy::implicit_return \
          -A clippy::default_numeric_fallback \
          -A clippy::std_instead_of_core \
          -A clippy::module_name_repetitions \
          -A clippy::question_mark_used \
          -A clippy::integer_division \
          -A clippy::shadow_reuse \
          -A clippy::single_call_fn \
          -A clippy::indexing_slicing \
          -A clippy::blanket_clippy_restriction_lints \
          -A clippy::missing_docs_in_private_items \
          -A clippy::std-instead-of-alloc \
          -A clippy::self_named_module_files \
          -A clippy::unseparated_literal_suffix \
          -A clippy::pub_use \
          -A clippy::partial_pub_fields \
          -A clippy::missing_trait_methods \
          -A clippy::float_arithmetic \
          -A clippy::cast_precision_loss \
          -A clippy::as_conversions \
          -A clippy::cast_possible_truncation \
          -A clippy::pattern_type_mismatch \
          -A clippy::integer_division_remainder_used \
          -A clippy::multiple-crate-versions || true
```

</details>