### PR TITLE
Line wrapping

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -346,7 +346,7 @@ fn run_default(opt: &mut Opt, config: &Config) -> Result<(), Error> {
         lap(&mut time, "Info: View::new");
     }
 
-    view.filter(opt, config, 0);
+    view.filter(opt, config, 1);
 
     if opt.debug {
         lap(&mut time, "Info: view.filter");

--- a/src/main.rs
+++ b/src/main.rs
@@ -346,7 +346,7 @@ fn run_default(opt: &mut Opt, config: &Config) -> Result<(), Error> {
         lap(&mut time, "Info: View::new");
     }
 
-    view.filter(opt, config);
+    view.filter(opt, config, 0);
 
     if opt.debug {
         lap(&mut time, "Info: view.filter");

--- a/src/view.rs
+++ b/src/view.rs
@@ -210,7 +210,7 @@ impl View {
         })
     }
 
-    pub fn filter(&mut self, opt: &Opt, config: &Config) {
+    pub fn filter(&mut self, opt: &Opt, config: &Config, header_lines: usize) {
         let mut cols_nonnumeric = Vec::new();
         let mut cols_numeric = Vec::new();
         for c in &self.columns {
@@ -321,7 +321,8 @@ impl View {
                 visible_pids.push(*pid);
             }
 
-            if opt.watch_mode && visible_pids.len() >= self.term_info.height - 5 {
+            let reserved_rows = 4 + header_lines;
+            if opt.watch_mode && visible_pids.len() >= self.term_info.height - reserved_rows {
                 break;
             }
         }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -67,7 +67,7 @@ impl Watcher {
         });
     }
 
-    fn display_header(term_info: &TermInfo, opt: &Opt, interval: u64) -> Result<(), Error> {
+    fn display_header(term_info: &TermInfo, opt: &Opt, interval: u64) -> Result<usize, Error> {
         let header = if opt.tree {
             format!(
                 " Interval: {}ms, Last Updated: {} ( Quit: q or Ctrl-C )",
@@ -81,13 +81,14 @@ impl Watcher {
                 Local::now().format("%Y/%m/%d %H:%M:%S"),
             )
         };
+        let result = header.len();
         term_info.write_line(&format!(
             "{}",
             console::style(header).white().bold().underlined()
         ))?;
 
         term_info.write_line("")?;
-        Ok(())
+        Ok(result.div_ceil(term_info.width))
     }
 
     pub fn start(opt: &mut Opt, config: &Config, interval: u64) -> Result<(), Error> {
@@ -116,18 +117,18 @@ impl Watcher {
                 view.sort_info.order = sort_order.clone().unwrap_or(view.sort_info.order);
             }
 
-            view.filter(opt, config);
-            view.adjust(config, &min_widths);
-            for (i, c) in view.columns.iter().enumerate() {
-                min_widths.insert(i, c.column.get_width());
-            }
-
             let resized = prev_term_width != view.term_info.width
                 || prev_term_height != view.term_info.height;
             if resized {
                 term_info.clear_screen()?;
             }
-            Watcher::display_header(&view.term_info, opt, interval)?;
+            let header_lines = Watcher::display_header(&view.term_info, opt, interval)?;
+
+            view.filter(opt, config, header_lines);
+            view.adjust(config, &min_widths);
+            for (i, c) in view.columns.iter().enumerate() {
+                min_widths.insert(i, c.column.get_width());
+            }
 
             view.display(opt, config, &theme)?;
 


### PR DESCRIPTION
Specifically when -w/--watch is specified, and the terminal is narrowed to the point where the header takes up more than one line, *and* there are more visible processes than are lines available on the screen, only the bottommost header line is displayed (at least on the terminal emulator "Terminal" on Debian). This is because the number of visible processes scrolls the view window and cuts off upper lines (I discovered this by using tmux's scrollback buffer to investigate what was above the confines of the regular screen). Such behavior can be seen with the output of `procs -w` on a 24x80 terminal:
![image](https://github.com/user-attachments/assets/f8edbf0f-b8a5-4a2d-b301-de878ebefb72)
This off-by-one error also causes the scrollback to get polluted with duplicate header lines, although this is simply annoying rather than detrimental (again running `procs -w`, just scrolling up a few lines):
![image](https://github.com/user-attachments/assets/032417b8-529f-4c8a-a76d-c89e7c8ec465)
This PR changes `Watcher::display_header` to return `Result<usize, Error>` where the `Ok` variant has the number of lines the header takes up, so that the the (new) `header_lines` parameter of `View::filter` can be populated. It also changes `View::filter` to break a bit earlier according to how many lines were taken up by the header, so as to prevent the two behaviors identified above.