### PR TITLE
Trim null byte from /proc/<pid>/attr/current

### DIFF
--- a/src/columns/sec_context.rs
+++ b/src/columns/sec_context.rs
@@ -37,7 +37,7 @@ impl Column for SecContext {
             if let Ok(mut file) = proc.open_relative("attr/current") {
                 let mut ret = String::new();
                 let _ = file.read_to_string(&mut ret);
-                ret.trim().to_string()
+                ret.trim_end_matches('\x00').to_string()
             } else {
                 String::from("")
             }


### PR DESCRIPTION
This made a ^@ show in `less` and made the columns misaligned because most terminals don't render null bytes, and one is present at the end of attr/current.

Replacing trim because it shouldn't have any spaces already.