### PR TITLE
Generate shell completions at build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,11 @@ tokio         = { version = "1.43", optional = true, features = ["rt"] }
 toml          = "0.8"
 unicode-width = "0.2"
 
+[build-dependencies]
+anyhow        = "1.0"
+clap          = {version = "4.4", features = ["derive"]}
+clap_complete = "4.4"
+
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 pager         = "0.16.1"
 procfs        = "0.17.0"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+include!("src/opt.rs");
+
+fn main() {
+    if let Ok(path) = std::env::var("COMPLETION_PATH") {
+        let out_dir = PathBuf::from(path);
+
+        gen_completion(Shell::Bash, &out_dir).unwrap();
+        gen_completion(Shell::Elvish, &out_dir).unwrap();
+        gen_completion(Shell::Fish, &out_dir).unwrap();
+        gen_completion(Shell::PowerShell, &out_dir).unwrap();
+        gen_completion(Shell::Zsh, &out_dir).unwrap();
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod column;
 mod columns;
 mod config;
+mod opt;
 mod process;
 mod style;
 mod term_info;
@@ -11,13 +12,12 @@ mod watcher;
 use crate::column::Column;
 use crate::columns::*;
 use crate::config::*;
-use crate::util::{adjust, get_theme, lap, ArgColorMode, ArgPagerMode, ArgThemeMode};
+use crate::opt::*;
+use crate::util::{adjust, get_theme, lap};
 use crate::view::View;
 use crate::watcher::Watcher;
-use anyhow::{anyhow, Context, Error};
-use clap::builder::styling::{AnsiColor, Effects, Styles};
-use clap::{CommandFactory, Parser, ValueEnum};
-use clap_complete::Shell;
+use anyhow::{Context, Error};
+use clap::{CommandFactory, Parser};
 use console::Term;
 use std::cmp;
 use std::collections::HashMap;
@@ -26,162 +26,6 @@ use std::io::{stdout, Read};
 use std::path::PathBuf;
 use std::time::Instant;
 use unicode_width::UnicodeWidthStr;
-
-// ---------------------------------------------------------------------------------------------------------------------
-// Opt
-// ---------------------------------------------------------------------------------------------------------------------
-
-#[derive(Clone, Debug, ValueEnum)]
-pub enum BuiltinConfig {
-    Default,
-    Large,
-}
-
-#[derive(Debug, Parser)]
-#[clap(long_version(option_env!("LONG_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))))]
-#[clap(
-    styles(Styles::styled()
-        .header(AnsiColor::Yellow.on_default() | Effects::BOLD)
-        .usage(AnsiColor::Yellow.on_default() | Effects::BOLD)
-        .literal(AnsiColor::Green.on_default() | Effects::BOLD)
-        .placeholder(AnsiColor::Cyan.on_default())
-    )
-)]
-/// A modern replacement for ps
-///
-/// please see https://github.com/dalance/procs#configuration to configure columns
-pub struct Opt {
-    /// Keywords for search
-    #[clap(action, name = "KEYWORD")]
-    pub keyword: Vec<String>,
-
-    /// AND  logic for multi-keyword
-    #[clap(
-        short = 'a',
-        long = "and",
-        conflicts_with_all(&["or", "nand", "nor"])
-    )]
-    pub and: bool,
-
-    /// OR   logic for multi-keyword
-    #[clap(
-        short = 'o',
-        long = "or",
-        conflicts_with_all(&["and", "nand", "nor"])
-    )]
-    pub or: bool,
-
-    /// NAND logic for multi-keyword
-    #[clap(
-        short = 'd',
-        long = "nand",
-        conflicts_with_all(&["and", "or", "nor"])
-    )]
-    pub nand: bool,
-
-    /// NOR  logic for multi-keyword
-    #[clap(
-        short = 'r',
-        long = "nor",
-        conflicts_with_all(&["and", "or", "nand"])
-    )]
-    pub nor: bool,
-
-    /// Show list of kind
-    #[clap(short = 'l', long = "list")]
-    pub list: bool,
-
-    /// Show thread
-    #[clap(long = "thread")]
-    pub thread: bool,
-
-    /// Tree view
-    #[clap(short = 't', long = "tree")]
-    pub tree: bool,
-
-    /// Watch mode with default interval (1s)
-    #[clap(short = 'w', long = "watch")]
-    pub watch: bool,
-
-    /// Watch mode with custom interval
-    #[clap(short = 'W', long = "watch-interval", value_name = "second")]
-    pub watch_interval: Option<f64>,
-
-    #[clap(skip)]
-    pub watch_mode: bool,
-
-    /// Insert column to slot
-    #[clap(value_name = "kind", short = 'i', long = "insert", number_of_values(1))]
-    pub insert: Vec<String>,
-
-    /// Specified column only
-    #[clap(value_name = "kind", long = "only")]
-    pub only: Option<String>,
-
-    /// Sort column by ascending
-    #[clap(
-        value_name = "kind",
-        long = "sorta",
-        conflicts_with_all(&["sortd", "tree"])
-    )]
-    pub sorta: Option<String>,
-
-    /// Sort column by descending
-    #[clap(
-        value_name = "kind",
-        long = "sortd",
-        conflicts_with_all(&["sorta", "tree"])
-    )]
-    pub sortd: Option<String>,
-
-    /// Color mode
-    #[clap(short = 'c', long = "color")]
-    pub color: Option<ArgColorMode>,
-
-    /// Theme mode
-    #[clap(long = "theme")]
-    pub theme: Option<ArgThemeMode>,
-
-    /// Pager mode
-    #[clap(short = 'p', long = "pager")]
-    pub pager: Option<ArgPagerMode>,
-
-    /// Interval to calculate throughput
-    #[clap(long = "interval", default_value = "100", value_name = "millisec")]
-    pub interval: u64,
-
-    /// Use built-in configuration
-    #[clap(long = "use-config", value_name = "name")]
-    pub use_config: Option<BuiltinConfig>,
-
-    /// Load configuration from file
-    #[clap(long = "load-config", value_name = "path")]
-    pub load_config: Option<PathBuf>,
-
-    /// Generate configuration sample file
-    #[clap(long = "gen-config")]
-    pub gen_config: bool,
-
-    /// Generate shell completion file
-    #[clap(long = "gen-completion", value_name = "shell")]
-    pub gen_completion: Option<Shell>,
-
-    /// Generate shell completion file and write to stdout
-    #[clap(long = "gen-completion-out", value_name = "shell")]
-    pub gen_completion_out: Option<Shell>,
-
-    /// Suppress header
-    #[clap(long = "no-header")]
-    pub no_header: bool,
-
-    /// Path to procfs
-    #[clap(long = "procfs")]
-    pub procfs: Option<PathBuf>,
-
-    /// Show debug message
-    #[clap(long = "debug", hide = true)]
-    pub debug: bool,
-}
 
 // ---------------------------------------------------------------------------------------------------------------------
 // Functions
@@ -278,18 +122,7 @@ fn run() -> Result<(), Error> {
         run_list();
         Ok(())
     } else if let Some(shell) = opt.gen_completion {
-        //Opt::clap().gen_completions("procs", shell, "./");
-        clap_complete::generate_to(shell, &mut Opt::command(), "procs", "./")?;
-        let path = match shell {
-            Shell::Bash => "./procs.bash",
-            Shell::Elvish => "./procs.elv",
-            Shell::Fish => "./procs.fish",
-            Shell::PowerShell => "./_procs.ps1",
-            Shell::Zsh => "./_procs",
-            x => return Err(anyhow!("unknown shell type: {}", x)),
-        };
-        println!("completion file is generated: {path}");
-        Ok(())
+        gen_completion(shell, "./")
     } else if let Some(shell) = opt.gen_completion_out {
         //Opt::clap().gen_completions_to("procs", shell, &mut stdout());
         clap_complete::generate(shell, &mut Opt::command(), "procs", &mut stdout());

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1,0 +1,200 @@
+use anyhow::{anyhow, Error};
+use clap::builder::styling::{AnsiColor, Effects, Styles};
+use clap::CommandFactory;
+use clap::{Parser, ValueEnum};
+use clap_complete::Shell;
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------------------------------------------------
+// Opt
+// ---------------------------------------------------------------------------------------------------------------------
+
+#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ArgColorMode {
+    Auto,
+    Always,
+    Disable,
+}
+
+#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ArgThemeMode {
+    Auto,
+    Dark,
+    Light,
+}
+
+#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ArgPagerMode {
+    Auto,
+    Always,
+    Disable,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum BuiltinConfig {
+    Default,
+    Large,
+}
+
+#[derive(Debug, Parser)]
+#[clap(long_version(option_env!("LONG_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))))]
+#[clap(
+    styles(Styles::styled()
+        .header(AnsiColor::Yellow.on_default() | Effects::BOLD)
+        .usage(AnsiColor::Yellow.on_default() | Effects::BOLD)
+        .literal(AnsiColor::Green.on_default() | Effects::BOLD)
+        .placeholder(AnsiColor::Cyan.on_default())
+    )
+)]
+/// A modern replacement for ps
+///
+/// please see https://github.com/dalance/procs#configuration to configure columns
+pub struct Opt {
+    /// Keywords for search
+    #[clap(action, name = "KEYWORD")]
+    pub keyword: Vec<String>,
+
+    /// AND  logic for multi-keyword
+    #[clap(
+        short = 'a',
+        long = "and",
+        conflicts_with_all(&["or", "nand", "nor"])
+    )]
+    pub and: bool,
+
+    /// OR   logic for multi-keyword
+    #[clap(
+        short = 'o',
+        long = "or",
+        conflicts_with_all(&["and", "nand", "nor"])
+    )]
+    pub or: bool,
+
+    /// NAND logic for multi-keyword
+    #[clap(
+        short = 'd',
+        long = "nand",
+        conflicts_with_all(&["and", "or", "nor"])
+    )]
+    pub nand: bool,
+
+    /// NOR  logic for multi-keyword
+    #[clap(
+        short = 'r',
+        long = "nor",
+        conflicts_with_all(&["and", "or", "nand"])
+    )]
+    pub nor: bool,
+
+    /// Show list of kind
+    #[clap(short = 'l', long = "list")]
+    pub list: bool,
+
+    /// Show thread
+    #[clap(long = "thread")]
+    pub thread: bool,
+
+    /// Tree view
+    #[clap(short = 't', long = "tree")]
+    pub tree: bool,
+
+    /// Watch mode with default interval (1s)
+    #[clap(short = 'w', long = "watch")]
+    pub watch: bool,
+
+    /// Watch mode with custom interval
+    #[clap(short = 'W', long = "watch-interval", value_name = "second")]
+    pub watch_interval: Option<f64>,
+
+    #[clap(skip)]
+    pub watch_mode: bool,
+
+    /// Insert column to slot
+    #[clap(value_name = "kind", short = 'i', long = "insert", number_of_values(1))]
+    pub insert: Vec<String>,
+
+    /// Specified column only
+    #[clap(value_name = "kind", long = "only")]
+    pub only: Option<String>,
+
+    /// Sort column by ascending
+    #[clap(
+        value_name = "kind",
+        long = "sorta",
+        conflicts_with_all(&["sortd", "tree"])
+    )]
+    pub sorta: Option<String>,
+
+    /// Sort column by descending
+    #[clap(
+        value_name = "kind",
+        long = "sortd",
+        conflicts_with_all(&["sorta", "tree"])
+    )]
+    pub sortd: Option<String>,
+
+    /// Color mode
+    #[clap(short = 'c', long = "color")]
+    pub color: Option<ArgColorMode>,
+
+    /// Theme mode
+    #[clap(long = "theme")]
+    pub theme: Option<ArgThemeMode>,
+
+    /// Pager mode
+    #[clap(short = 'p', long = "pager")]
+    pub pager: Option<ArgPagerMode>,
+
+    /// Interval to calculate throughput
+    #[clap(long = "interval", default_value = "100", value_name = "millisec")]
+    pub interval: u64,
+
+    /// Use built-in configuration
+    #[clap(long = "use-config", value_name = "name")]
+    pub use_config: Option<BuiltinConfig>,
+
+    /// Load configuration from file
+    #[clap(long = "load-config", value_name = "path")]
+    pub load_config: Option<PathBuf>,
+
+    /// Generate configuration sample file
+    #[clap(long = "gen-config")]
+    pub gen_config: bool,
+
+    /// Generate shell completion file
+    #[clap(long = "gen-completion", value_name = "shell")]
+    pub gen_completion: Option<Shell>,
+
+    /// Generate shell completion file and write to stdout
+    #[clap(long = "gen-completion-out", value_name = "shell")]
+    pub gen_completion_out: Option<Shell>,
+
+    /// Suppress header
+    #[clap(long = "no-header")]
+    pub no_header: bool,
+
+    /// Path to procfs
+    #[clap(long = "procfs")]
+    pub procfs: Option<PathBuf>,
+
+    /// Show debug message
+    #[clap(long = "debug", hide = true)]
+    pub debug: bool,
+}
+
+pub fn gen_completion<P: AsRef<Path>>(shell: Shell, path: P) -> Result<(), Error> {
+    let path_str = path.as_ref().as_os_str();
+    //Opt::clap().gen_completions("procs", shell, path_str);
+    clap_complete::generate_to(shell, &mut Opt::command(), "procs", path_str)?;
+    let filename = match shell {
+        Shell::Bash => "procs.bash",
+        Shell::Elvish => "procs.elv",
+        Shell::Fish => "procs.fish",
+        Shell::PowerShell => "_procs.ps1",
+        Shell::Zsh => "_procs",
+        x => return Err(anyhow!("unknown shell type: {}", x)),
+    };
+    let path = path.as_ref().join(filename);
+    println!("completion file is generated: {}", path.display());
+    Ok(())
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,9 @@
 use crate::column::Column;
 use crate::columns::{ConfigColumnKind, KIND_LIST};
 use crate::config::{Config, ConfigColumnAlign, ConfigSearchCase, ConfigSearchLogic, ConfigTheme};
+use crate::opt::ArgThemeMode;
 use crate::Opt;
 use byte_unit::{Byte, UnitType};
-use clap::ValueEnum;
 use std::borrow::Cow;
 use std::io;
 use std::io::IsTerminal;
@@ -13,20 +13,6 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 #[cfg(not(target_os = "windows"))]
 use uzers::UsersCache;
 
-#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ArgColorMode {
-    Auto,
-    Always,
-    Disable,
-}
-
-#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ArgThemeMode {
-    Auto,
-    Dark,
-    Light,
-}
-
 impl From<ArgThemeMode> for ConfigTheme {
     fn from(item: ArgThemeMode) -> Self {
         match item {
@@ -35,13 +21,6 @@ impl From<ArgThemeMode> for ConfigTheme {
             ArgThemeMode::Light => ConfigTheme::Light,
         }
     }
-}
-
-#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ArgPagerMode {
-    Auto,
-    Always,
-    Disable,
 }
 
 pub enum KeywordClass {

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,13 +1,11 @@
 use crate::column::Column;
 use crate::columns::*;
 use crate::config::*;
+use crate::opt::{ArgColorMode, ArgPagerMode};
 use crate::process::collect_proc;
 use crate::style::{apply_color, apply_style, color_to_column_style};
 use crate::term_info::TermInfo;
-use crate::util::{
-    classify, find_column_kind, find_exact, find_partial, truncate, ArgColorMode, ArgPagerMode,
-    KeywordClass,
-};
+use crate::util::{classify, find_column_kind, find_exact, find_partial, truncate, KeywordClass};
 use crate::Opt;
 use anyhow::{bail, Error};
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
Hello.

I'm marking this PR as a draft since I don't know if you are interested in this feature, and if you are, whether you would be happy with this implementation. Since there has been no previous discussion of this, if you are not interested there will be no hard feelings :-)


I maintain procs in Debian, and one issue I have is its deb package cannot be cross-compiled because to generate shell completions one has to execute the procs binary itself. One way this can be overcome is by generating completions at build time using a build.rs file, which is compiled for the build machine instead of the host.

This PR implements generation of shell completions at build time by factoring out the necessary structures and functionality in a new `src/opt.rs` module. The latter includes `Opt`, `ArgColorMode`, `ArgThemeMode` , `ArgPagerMode`, `BuiltinConfig` and a new function, `gen_completion`, which is responsible for actually generating completions (both at run time as before and at build time). To avoid creating an extra library for build.rs to `use` (which is totally fine as far as I'm concerned), `src/opt.rs` is included as-is in build.rs using the `include!` macro. One downside of doing so is that all crates used by the `src/opt.rs` module must be added as build dependencies (which is pretty obvious since they now become actual dependencies of build.rs).

Cheers!

