### PR TITLE
Add nvcsw and nivcsw

### DIFF
--- a/src/columns/non_voluntary_context_sw.rs
+++ b/src/columns/non_voluntary_context_sw.rs
@@ -1,0 +1,62 @@
+use crate::process::ProcessInfo;
+use crate::util::bytify;
+use crate::{column_default, Column};
+use std::cmp;
+use std::collections::HashMap;
+
+pub struct NonVoluntaryContextSw {
+    header: String,
+    unit: String,
+    fmt_contents: HashMap<i32, String>,
+    raw_contents: HashMap<i32, u64>,
+    width: usize,
+}
+
+impl NonVoluntaryContextSw {
+    pub fn new(header: Option<String>) -> Self {
+        let header = header.unwrap_or_else(|| String::from("NonVoluntaryContextSw"));
+        let unit = String::new();
+        Self {
+            fmt_contents: HashMap::new(),
+            raw_contents: HashMap::new(),
+            width: 0,
+            header,
+            unit,
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl Column for NonVoluntaryContextSw {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let (fmt_content, raw_content) = if let Some(ref status) = proc.curr_status {
+            if status.nonvoluntary_ctxt_switches.is_some()
+            {
+                let sw = status.nonvoluntary_ctxt_switches.unwrap();
+                (bytify(sw), sw)
+            } else {
+                (String::new(), 0)
+            }
+        } else {
+            (String::new(), 0)
+        };
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(u64, true);
+}
+
+#[cfg(target_os = "freebsd")]
+impl Column for NonVoluntaryContextSw {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let raw_content = proc.curr_proc.info.rusage.nivcsw as u64;
+        let fmt_content = bytify(raw_content);
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(u64, true);
+}

--- a/src/columns/os_linux.rs
+++ b/src/columns/os_linux.rs
@@ -2,6 +2,8 @@ pub mod ccgroup;
 pub mod cgroup;
 pub mod command;
 pub mod context_sw;
+pub mod voluntary_context_sw;
+pub mod non_voluntary_context_sw;
 pub mod cpu_time;
 #[cfg(feature = "docker")]
 pub mod docker;
@@ -81,6 +83,8 @@ pub use self::ccgroup::Ccgroup;
 pub use self::cgroup::Cgroup;
 pub use self::command::Command;
 pub use self::context_sw::ContextSw;
+pub use self::voluntary_context_sw::VoluntaryContextSw;
+pub use self::non_voluntary_context_sw::NonVoluntaryContextSw;
 pub use self::cpu_time::CpuTime;
 #[cfg(feature = "docker")]
 pub use self::docker::Docker;
@@ -172,6 +176,8 @@ pub enum ConfigColumnKind {
     Cgroup,
     Command,
     ContextSw,
+    VoluntaryContextSw,
+    NonVoluntaryContextSw,
     CpuTime,
     Docker,
     Eip,
@@ -266,6 +272,8 @@ pub fn gen_column(
         ConfigColumnKind::Cgroup => Box::new(Cgroup::new(header)),
         ConfigColumnKind::Command => Box::new(Command::new(header)),
         ConfigColumnKind::ContextSw => Box::new(ContextSw::new(header)),
+        ConfigColumnKind::VoluntaryContextSw => Box::new(VoluntaryContextSw::new(header)),
+        ConfigColumnKind::NonVoluntaryContextSw => Box::new(NonVoluntaryContextSw::new(header)),
         ConfigColumnKind::CpuTime => Box::new(CpuTime::new(header)),
         #[cfg(feature = "docker")]
         ConfigColumnKind::Docker => Box::new(Docker::new(header, _docker_path)),
@@ -365,6 +373,14 @@ pub static KIND_LIST: Lazy<BTreeMap<ConfigColumnKind, (&'static str, &'static st
             (
                 ConfigColumnKind::ContextSw,
                 ("ContextSw", "Context switch count"),
+            ),
+            (
+                ConfigColumnKind::VoluntaryContextSw,
+                ("VoluntaryContextSw", "Voluntary context switch count"),
+            ),
+            (
+                ConfigColumnKind::NonVoluntaryContextSw,
+                ("NonVoluntaryContextSw", "Nonvoluntary context switch count"),
             ),
             (
                 ConfigColumnKind::CpuTime,
@@ -746,6 +762,14 @@ style = "BrightRed"
 align = "Left"
 [[columns]]
 kind = "ContextSw"
+style = "BrightRed"
+align = "Right"
+[[columns]]
+kind = "VoluntaryContextSw"
+style = "BrightRed"
+align = "Right"
+[[columns]]
+kind = "NonVoluntaryContextSw"
 style = "BrightRed"
 align = "Right"
 [[columns]]

--- a/src/columns/voluntary_context_sw.rs
+++ b/src/columns/voluntary_context_sw.rs
@@ -1,0 +1,63 @@
+use crate::process::ProcessInfo;
+use crate::util::bytify;
+use crate::{column_default, Column};
+use std::cmp;
+use std::collections::HashMap;
+
+pub struct VoluntaryContextSw {
+    header: String,
+    unit: String,
+    fmt_contents: HashMap<i32, String>,
+    raw_contents: HashMap<i32, u64>,
+    width: usize,
+}
+
+impl VoluntaryContextSw {
+    pub fn new(header: Option<String>) -> Self {
+        let header = header.unwrap_or_else(|| String::from("VoluntaryContextSw"));
+        let unit = String::new();
+        Self {
+            fmt_contents: HashMap::new(),
+            raw_contents: HashMap::new(),
+            width: 0,
+            header,
+            unit,
+        }
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+impl Column for VoluntaryContextSw {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let (fmt_content, raw_content) = if let Some(ref status) = proc.curr_status {
+            if status.voluntary_ctxt_switches.is_some()
+            {
+                let sw = status.voluntary_ctxt_switches.unwrap();
+                (bytify(sw), sw)
+            } else {
+                (String::new(), 0)
+            }
+        } else {
+            (String::new(), 0)
+        };
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(u64, true);
+}
+
+#[cfg(target_os = "freebsd")]
+impl Column for VoluntaryContextSw {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let raw_content =
+            proc.curr_proc.info.rusage.nvcsw as u64;
+        let fmt_content = bytify(raw_content);
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(u64, true);
+}


### PR DESCRIPTION
Add nvcsw and nivcsw -- number of voluntary context switches and number of involuntary context switches to platforms supporting these. Roughly (and IIUC), voluntary context switches are when threads sleep or yield, involuntary are when threads are preempted.

I named these Voluntary and NonVoluntary context switches. I've seen both names used, not sure which is more common, but I think that is.

![image](https://github.com/user-attachments/assets/756c3cbc-2a58-4a16-96de-7e28c7b3d9ac)

These are super useful for when working with performance and scheduler related things.