### PR TITLE
use actual macos memory usage from libproc pid_rusage

### DIFF
--- a/src/columns/usage_mem.rs
+++ b/src/columns/usage_mem.rs
@@ -111,7 +111,12 @@ impl Column for UsageMem {
 #[cfg(target_os = "macos")]
 impl Column for UsageMem {
     fn add(&mut self, proc: &ProcessInfo) {
-        let usage = proc.curr_task.ptinfo.pti_resident_size as f64 * 100.0 / self.mem_total as f64;
+        let usage = match &proc.curr_res {
+            Some(mem) => mem.ri_phys_footprint,
+            None => proc.curr_task.ptinfo.pti_resident_size,
+        } as f64
+            * 100.0
+            / self.mem_total as f64;
         let fmt_content = format!("{:.1}", usage);
         let raw_content = (usage * 1000.0) as u32;
 


### PR DESCRIPTION
I'd also like to add a column to show the raw bytes from `ri_phys_footprint`, but i'm not sure if i should create a new column or which existing column to use (I'm thinking of making a new VmTotal or VmPss column, which could be calculated appropriately for other operating systems)