### PR TITLE
docs: fix README wording for macOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 - Linux is supported.
 - macOS is experimentally supported.
-    - macOS version is checked on GitHub Actions environment only.
+    - macOS version is checked only in the GitHub Actions environment.
     - The issues caused by real-machine are welcome.
 - Windows is supported.
 - FreeBSD is experimentally supported.


### PR DESCRIPTION
## Summary
- fix the README wording for the macOS support note.

## Related issue
- N/A; trivial docs wording fix.

## Guideline alignment
- No CONTRIBUTING or PR template was present; kept this to a one-file README wording fix with no behavior change.

## Validation
- Not run; docs-only change.
