### PR TITLE
fix: append ANSI reset after trimming to prevent terminal color bleed

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -232,7 +232,14 @@ pub fn ansi_trim_end(s: &str) -> String {
     if trimmed_width == UnicodeWidthStr::width(stripped.as_ref()) {
         return s.to_string();
     }
-    truncate(s, trimmed_width).into_owned()
+    // Truncating drops any ANSI reset code that was at the end of the original
+    // string, which leaves color/style open in the terminal. Append an explicit
+    // reset so every trimmed line always ends in a clean state.
+    let mut result = truncate(s, trimmed_width).into_owned();
+    if stripped.as_ref() != s {
+        result.push_str("\x1b[0m");
+    }
+    result
 }
 
 pub fn find_column_kind(pat: &str) -> Option<ConfigColumnKind> {


### PR DESCRIPTION
Fixes #778

## Root Cause

`ansi_trim_end()` detects trailing whitespace in colored output by stripping ANSI codes, measuring the trimmed visual width, then calling `truncate(s, trimmed_width)` to remove the trailing spaces from the ANSI-wrapped string.

`truncate()` stops at the first character that would exceed `trimmed_width` and returns everything up to that point — discarding any ANSI escape sequences that appeared after it, including the `\x1b[0m` reset code at the end of the last styled column.

**Result:** when the last visible column has trailing padding (content shorter than column width), the reset code is dropped, leaving the terminal in a styled state (bold/white) after procs exits.

## Fix

After truncation, append an explicit `\x1b[0m` reset when the input contained ANSI codes (detected by comparing `stripped != s`). This ensures every trimmed line ends in a clean terminal state without affecting plain-text output paths.

```
Before: \x1b[38;5;15mCommand\n         (color/bold left open)
After:  \x1b[38;5;15mCommand\x1b[0m\n  (properly reset)
```

Verified by piping `procs --color=always` through `cat -A`: each row now ends with `\x1b[0m` before the newline.