### PR TITLE
Strip terminal escape sequences from the Command column

### DIFF
--- a/src/columns/command.rs
+++ b/src/columns/command.rs
@@ -47,6 +47,7 @@ impl Column for Command {
         } else {
             proc.curr_proc.stat().comm.clone()
         };
+        let fmt_content = crate::util::sanitize_display(&fmt_content);
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);
@@ -79,6 +80,7 @@ impl Column for Command {
         } else {
             String::from("")
         };
+        let fmt_content = crate::util::sanitize_display(&fmt_content);
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);
@@ -91,7 +93,7 @@ impl Column for Command {
 #[cfg(target_os = "windows")]
 impl Column for Command {
     fn add(&mut self, proc: &ProcessInfo) {
-        let fmt_content = proc.command.clone();
+        let fmt_content = crate::util::sanitize_display(&proc.command);
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);
@@ -119,7 +121,7 @@ impl Column for Command {
             }
             x
         };
-        let fmt_content = command;
+        let fmt_content = crate::util::sanitize_display(&command);
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);

--- a/src/util.rs
+++ b/src/util.rs
@@ -223,6 +223,19 @@ pub fn truncate(s: &'_ str, width: usize) -> Cow<'_, str> {
     }
 }
 
+/// Replace control characters, including ANSI/terminal escape sequences,
+/// with the Unicode replacement character. Process-derived content (such
+/// as a command line) is fully controlled by whichever user started the
+/// process, so it must be sanitized before being written to the
+/// terminal, since an unprivileged local user could otherwise plant an
+/// escape sequence that gets interpreted by any other user's terminal
+/// when they view the process listing.
+pub fn sanitize_display(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { '\u{FFFD}' } else { c })
+        .collect()
+}
+
 /// Trim trailing whitespace from a string that may contain ANSI escape sequences.
 /// Unlike str::trim_end(), this correctly handles ANSI codes at the end of the string
 /// that would otherwise prevent trimming of trailing whitespace.
@@ -381,5 +394,29 @@ pub fn process_new(
         procfs::process::Process::new_with_root(path)
     } else {
         procfs::process::Process::new(pid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_display_strips_escape_sequences() {
+        // A crafted argv0 embedding a raw OSC 52 (clipboard-write) escape
+        // sequence, the same shape a malicious local process could use to
+        // inject terminal control sequences into another user's `procs`
+        // output. The ESC and BEL bytes must not survive sanitization.
+        let malicious = "\x1b]52;c;cGF5bG9hZA==\x07innocuous_process";
+        let sanitized = sanitize_display(malicious);
+        assert!(!sanitized.contains('\u{1b}'));
+        assert!(!sanitized.contains('\u{7}'));
+        assert!(sanitized.contains("innocuous_process"));
+    }
+
+    #[test]
+    fn sanitize_display_preserves_normal_text() {
+        let normal = "/usr/bin/env python3 script.py --flag value";
+        assert_eq!(sanitize_display(normal), normal);
     }
 }


### PR DESCRIPTION
Fixes #950.

## Summary

`Command::add` (src/columns/command.rs) read each process's command line
and only replaced newline and tab characters before displaying it, with
no handling of other control characters or ANSI/terminal escape
sequences. Since a process's command line (including `argv[0]`) is fully
controlled by whichever user started it, and `/proc/<pid>/cmdline` is
world-readable on Linux regardless of process ownership, any local
unprivileged user could plant a process whose command line contains a
raw escape sequence. That sequence would then be printed unmodified to
any other user's terminal the moment they ran `procs`, since displaying
every visible process is the tool's whole purpose, not an action taken
with awareness of viewing untrusted content the way opening a specific
file is.

## Fix

Adds `util::sanitize_display`, which replaces control characters
(including the `ESC` byte, `0x1b`) with the Unicode replacement
character, and applies it to the final command-line string in all four
platform variants of `Command::add` (Linux/Android, macOS, Windows,
FreeBSD). The existing newline/tab-to-space replacement is kept as-is;
this is an additional pass on top of it.

## Testing

- `cargo test --release` passes in full (15 passed, up from 13 with the
  2 new tests, 0 failed).
- Added `sanitize_display_strips_escape_sequences` and
  `sanitize_display_preserves_normal_text` to `src/util.rs`.
- Manually reproduced the issue against an unpatched build: spawned a
  detached process (`subprocess.Popen` with a crafted `argv[0]` containing
  a raw OSC 52 escape sequence, `executable=` pointing at `sleep` so the
  actual command run was harmless), ran `procs` against it, and confirmed
  the exact injected byte sequence appeared unmodified in `procs`'s raw
  output. Repeated against this branch and confirmed the `ESC`/`BEL`
  bytes are replaced with the Unicode replacement character instead.
