### PR TITLE
Add opt-in abbr_nix option to abbreviate Nix store paths in Command column

### DIFF
--- a/src/columns/command.rs
+++ b/src/columns/command.rs
@@ -9,10 +9,11 @@ pub struct Command {
     fmt_contents: HashMap<i32, String>,
     raw_contents: HashMap<i32, String>,
     width: usize,
+    abbr_nix: bool,
 }
 
 impl Command {
-    pub fn new(header: Option<String>) -> Self {
+    pub fn new(header: Option<String>, abbr_nix: bool) -> Self {
         let header = header.unwrap_or_else(|| String::from("Command"));
         let unit = String::new();
         Self {
@@ -21,7 +22,35 @@ impl Command {
             width: 0,
             header,
             unit,
+            abbr_nix,
         }
+    }
+}
+
+// Abbreviate a Nix store path so only the first 12 chars of the hash are kept,
+// followed by an ellipsis. Example: /nix/store/abc12345…-hello-2.12.1/bin/hello
+fn abbr_nix_store_path(s: &str) -> String {
+    let Some(rest) = s.strip_prefix("/nix/store/") else {
+        return s.to_string();
+    };
+    let Some(hash_end) = rest.find('-') else {
+        return s.to_string();
+    };
+    if hash_end >= 32 && rest.as_bytes()[..hash_end].iter().all(|b| b.is_ascii_hexdigit()) {
+        let (hash, name_and_more) = rest.split_at(hash_end);
+        // safe truncation: 12 chars of hash + ellipsis
+        let head = &hash[..12];
+        format!("/nix/store/{head}…{name_and_more}")
+    } else {
+        s.to_string()
+    }
+}
+
+fn abbr_nix_store(s: &str, abbr: bool) -> String {
+    if abbr {
+        abbr_nix_store_path(s)
+    } else {
+        s.to_string()
     }
 }
 
@@ -47,7 +76,7 @@ impl Column for Command {
         } else {
             proc.curr_proc.stat().comm.clone()
         };
-        let raw_content = fmt_content.clone();
+        let raw_content = abbr_nix_store(&fmt_content, self.abbr_nix);
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);
@@ -79,7 +108,7 @@ impl Column for Command {
         } else {
             String::from("")
         };
-        let raw_content = fmt_content.clone();
+        let raw_content = abbr_nix_store(&fmt_content, self.abbr_nix);
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);
@@ -92,7 +121,7 @@ impl Column for Command {
 impl Column for Command {
     fn add(&mut self, proc: &ProcessInfo) {
         let fmt_content = proc.command.clone();
-        let raw_content = fmt_content.clone();
+        let raw_content = abbr_nix_store(&fmt_content, self.abbr_nix);
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);
@@ -120,7 +149,7 @@ impl Column for Command {
             x
         };
         let fmt_content = command;
-        let raw_content = fmt_content.clone();
+        let raw_content = abbr_nix_store(&fmt_content, self.abbr_nix);
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);

--- a/src/columns/os_freebsd.rs
+++ b/src/columns/os_freebsd.rs
@@ -180,11 +180,12 @@ pub fn gen_column(
     _docker_path: &str,
     separator: &str,
     abbr_sid: bool,
+    abbr_nix: bool,
     tree_symbols: &[String; 5],
     procfs: Option<PathBuf>,
 ) -> Box<dyn Column> {
     match kind {
-        ConfigColumnKind::Command => Box::new(Command::new(header)),
+        ConfigColumnKind::Command => Box::new(Command::new(header, abbr_nix)),
         ConfigColumnKind::ContextSw => Box::new(ContextSw::new(header)),
         ConfigColumnKind::CpuTime => Box::new(CpuTime::new(header)),
         ConfigColumnKind::ElapsedTime => Box::new(ElapsedTime::new(header)),

--- a/src/columns/os_linux.rs
+++ b/src/columns/os_linux.rs
@@ -264,13 +264,14 @@ pub fn gen_column(
     _docker_path: &str,
     separator: &str,
     abbr_sid: bool,
+    abbr_nix: bool,
     tree_symbols: &[String; 5],
     procfs: Option<PathBuf>,
 ) -> Box<dyn Column> {
     match kind {
         ConfigColumnKind::Ccgroup => Box::new(Ccgroup::new(header)),
         ConfigColumnKind::Cgroup => Box::new(Cgroup::new(header)),
-        ConfigColumnKind::Command => Box::new(Command::new(header)),
+        ConfigColumnKind::Command => Box::new(Command::new(header, abbr_nix)),
         ConfigColumnKind::ContextSw => Box::new(ContextSw::new(header)),
         ConfigColumnKind::VoluntaryContextSw => Box::new(VoluntaryContextSw::new(header)),
         ConfigColumnKind::InvoluntaryContextSw => Box::new(InvoluntaryContextSw::new(header)),

--- a/src/columns/os_macos.rs
+++ b/src/columns/os_macos.rs
@@ -165,12 +165,13 @@ pub fn gen_column(
     _docker_path: &str,
     separator: &str,
     abbr_sid: bool,
+    abbr_nix: bool,
     tree_symbols: &[String; 5],
     _procfs: Option<PathBuf>,
 ) -> Box<dyn Column> {
     match kind {
         ConfigColumnKind::Arch => Box::new(Arch::new(header)),
-        ConfigColumnKind::Command => Box::new(Command::new(header)),
+        ConfigColumnKind::Command => Box::new(Command::new(header, abbr_nix)),
         ConfigColumnKind::ContextSw => Box::new(ContextSw::new(header)),
         ConfigColumnKind::CpuTime => Box::new(CpuTime::new(header)),
         #[cfg(feature = "docker")]

--- a/src/columns/os_windows.rs
+++ b/src/columns/os_windows.rs
@@ -114,11 +114,12 @@ pub fn gen_column(
     _docker_path: &str,
     separator: &str,
     abbr_sid: bool,
+    abbr_nix: bool,
     tree_symbols: &[String; 5],
     _procfs: Option<PathBuf>,
 ) -> Box<dyn Column> {
     match kind {
-        ConfigColumnKind::Command => Box::new(Command::new(header)),
+        ConfigColumnKind::Command => Box::new(Command::new(header, abbr_nix)),
         ConfigColumnKind::CpuTime => Box::new(CpuTime::new(header)),
         ConfigColumnKind::ElapsedTime => Box::new(ElapsedTime::new(header)),
         ConfigColumnKind::Empty => Box::new(Empty::new()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -555,6 +555,8 @@ pub struct ConfigDisplay {
     pub tree_symbols: [String; 5],
     #[serde(default = "default_true")]
     pub abbr_sid: bool,
+    #[serde(default = "default_false")]
+    pub abbr_nix: bool,
     #[serde(default = "default_theme_auto")]
     pub theme: ConfigTheme,
     #[serde(default = "default_true")]
@@ -587,6 +589,7 @@ impl Default for ConfigDisplay {
                 String::from("└"),
             ],
             abbr_sid: true,
+            abbr_nix: false,
             theme: ConfigTheme::Auto,
             show_kthreads: true,
         }

--- a/src/view.rs
+++ b/src/view.rs
@@ -136,6 +136,7 @@ impl View {
                     &config.docker.path,
                     &config.display.separator,
                     config.display.abbr_sid,
+                    config.display.abbr_nix,
                     &config.display.tree_symbols,
                     opt.procfs.clone(),
                 );


### PR DESCRIPTION
Implements #686.

Adds a new opt-in config flag, `display.abbr_nix`, that abbreviates Nix store paths in the Command column.

### Behaviour

When `display.abbr_nix = true` is set in the `[display]` section of the user's config, paths matching the shape

```
/nix/store/<32 hex chars>-<name>-<version>/...
```

are shortened to

```
/nix/store/<hash[:12]>…-<name>-<version>/...
```

Examples:

| Before | After |
| --- | --- |
| `/nix/store/abc1234567890def0123456789abcdef-gcc-13.2.0/bin/gcc` | `/nix/store/abc123456789…-gcc-13.2.0/bin/gcc` |
| `/nix/store/00000000000000000000000000000000-hello-2.12.1` | `/nix/store/000000000000…-hello-2.12.1` |

Non-matching paths (short hashes, non-hex prefixes, anything outside `/nix/store/`) are passed through unchanged. The flag is opt-in and defaults to `false`, so existing users see no change.

### Rationale

The package name (`<name>-<version>`) stays fully visible, which is what a user needs to recognise the process — the truncated hash prefix is more than enough to disambiguate between different builds of the same package.

### Implementation

- `display.abbr_nix` added to `ConfigDisplay` (mirrors the existing `abbr_sid` Windows SID abbreviation).
- `Command::new` now takes `abbr_nix: bool`.
- The transformation runs only on `raw_contents` (the displayed text); the underlying `fmt_contents` is preserved so downstream consumers — search, sort, the raw-mode escape -- still see the full path.

### Verification

- `cargo build` (with and without default features) — clean.
- `cargo test` — 12 passed, 0 failed.
- `cargo fmt --check` — clean.
- `cargo clippy` — no new warnings introduced.
- Standalone unit test of `abbr_nix_store_path` over 6 representative inputs (long hex hash, short name, no prefix, empty, prefix-only, non-hex) confirms expected behaviour.