### PR TITLE
Strip control characters from the Command column (fixes #950)

### DIFF
--- a/src/columns/command.rs
+++ b/src/columns/command.rs
@@ -1,4 +1,5 @@
 use crate::process::ProcessInfo;
+use crate::util::sanitize_control_chars;
 use crate::{column_default, Column};
 use std::cmp;
 use std::collections::HashMap;
@@ -39,7 +40,6 @@ impl Column for Command {
                     })
                     .collect::<String>();
                 cmd.pop();
-                cmd = cmd.replace(['\n', '\t'], " ");
                 cmd
             } else {
                 format!("[{}]", proc.curr_proc.stat().comm)
@@ -47,6 +47,7 @@ impl Column for Command {
         } else {
             proc.curr_proc.stat().comm.clone()
         };
+        let fmt_content = sanitize_control_chars(&fmt_content);
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);
@@ -71,7 +72,6 @@ impl Column for Command {
                     })
                     .collect::<String>();
                 cmd.pop();
-                cmd = cmd.replace(['\n', '\t'], " ");
                 cmd
             } else {
                 String::from("")
@@ -79,6 +79,7 @@ impl Column for Command {
         } else {
             String::from("")
         };
+        let fmt_content = sanitize_control_chars(&fmt_content);
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);
@@ -92,6 +93,7 @@ impl Column for Command {
 impl Column for Command {
     fn add(&mut self, proc: &ProcessInfo) {
         let fmt_content = proc.command.clone();
+        let fmt_content = sanitize_control_chars(&fmt_content);
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);
@@ -120,6 +122,7 @@ impl Column for Command {
             x
         };
         let fmt_content = command;
+        let fmt_content = sanitize_control_chars(&fmt_content);
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);

--- a/src/util.rs
+++ b/src/util.rs
@@ -223,6 +223,15 @@ pub fn truncate(s: &'_ str, width: usize) -> Cow<'_, str> {
     }
 }
 
+/// Replace control characters with spaces.
+///
+/// Process command lines are fully attacker-controlled, so any ESC/CSI/OSC
+/// sequence they contain would otherwise be interpreted by the terminal of
+/// whoever runs procs.
+pub fn sanitize_control_chars(s: &str) -> String {
+    s.replace(|c: char| char::is_control(c), " ")
+}
+
 /// Trim trailing whitespace from a string that may contain ANSI escape sequences.
 /// Unlike str::trim_end(), this correctly handles ANSI codes at the end of the string
 /// that would otherwise prevent trimming of trailing whitespace.
@@ -381,5 +390,25 @@ pub fn process_new(
         procfs::process::Process::new_with_root(path)
     } else {
         procfs::process::Process::new(pid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_control_chars() {
+        // OSC 52 clipboard-write sequence embedded in a crafted argv0
+        let injected = "\u{1b}]52;c;bWFya2Vy\u{7}sleep\t60\nrm -rf /";
+        let sanitized = sanitize_control_chars(injected);
+        assert_eq!(sanitized, " ]52;c;bWFya2Vy sleep 60 rm -rf /");
+        assert!(!sanitized.chars().any(char::is_control));
+
+        // CSI sequences are neutralized too
+        assert_eq!(sanitize_control_chars("\u{1b}[2J\u{1b}[H"), " [2J [H");
+
+        // Normal command lines are untouched
+        assert_eq!(sanitize_control_chars("/bin/sleep 60"), "/bin/sleep 60");
     }
 }


### PR DESCRIPTION
Fixes #950.

## Problem

`Command::add` only replaced `\n` and `\t` before display. A process's command line — including argv[0] — is fully controlled by whoever started it, and `/proc/<pid>/cmdline` is world-readable, so any local user can plant a process whose command line contains a raw ESC/CSI/OSC sequence. When another user runs `procs`, that sequence reaches their terminal unmodified.

## Fix

Adds `util::sanitize_control_chars`, which replaces every control character (C0 including ESC 0x1B and BEL 0x07, DEL, and C1) with a space, and applies it to the final `Command` value on all four platform impls (Linux/Android, macOS, Windows, FreeBSD). This supersedes the old newline/tab replacement, which is now a subset of the same rule.

Replacing rather than deleting keeps the surrounding text visible and the column width honest; the payload's remaining printable bytes (e.g. `]52;c;...`) show up as inert text.

Scope is deliberately limited to the Command column, as reported.

## Test

`util::tests::test_sanitize_control_chars` uses the reporter's scenario — an OSC 52 clipboard-write sequence wrapping a base64 marker, plus embedded tab/newline — and asserts the output contains no control characters, that CSI sequences are neutralized, and that ordinary command lines pass through unchanged.

## Verification

Run on macOS.

```
$ cargo test
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo fmt --check
(clean, no output)

$ cargo clippy --all-targets -- -D warnings
12 pre-existing errors, byte-identical to the `git stash` baseline on the
same commit (unsafe_op_in_unsafe_fn in the macOS paths, collapsible_if,
unnecessary_cast, etc.). No new lints introduced by this change.
```

## Disclosure

This patch was written with AI assistance (Claude). I reviewed the diff and ran the verification commands above myself.