### PR TITLE
fix: emit ANSI reset when truncation drops it (#778)

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -13,6 +13,8 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 #[cfg(not(target_os = "windows"))]
 use uzers::UsersCache;
 
+const ANSI_RESET: &str = "\u{1b}[0m";
+
 impl From<ArgThemeMode> for ConfigTheme {
     fn from(item: ArgThemeMode) -> Self {
         match item {
@@ -216,7 +218,12 @@ pub fn truncate(s: &'_ str, width: usize) -> Cow<'_, str> {
         }
         buf.push(c);
     }
-    if let Some(buf) = ret {
+    if let Some(mut buf) = ret {
+        // Truncation discards everything after the cut point, including any trailing
+        // ANSI reset. Without it the terminal keeps the last style after procs exits.
+        if buf.contains('\u{1b}') {
+            buf.push_str(ANSI_RESET);
+        }
         Cow::Owned(buf)
     } else {
         Cow::Borrowed(s)
@@ -381,5 +388,37 @@ pub fn process_new(
         procfs::process::Process::new_with_root(path)
     } else {
         procfs::process::Process::new(pid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_keeps_reset_for_styled_text() {
+        let styled = "\u{1b}[1;37mabcdef\u{1b}[0m";
+        assert_eq!(truncate(styled, 3), "\u{1b}[1;37mabc\u{1b}[0m");
+    }
+
+    #[test]
+    fn test_truncate_plain_text_unchanged() {
+        assert_eq!(truncate("abcdef", 3), "abc");
+        assert_eq!(truncate("abcdef", 6), "abcdef");
+    }
+
+    #[test]
+    fn test_ansi_trim_end_keeps_reset() {
+        // Trailing padding inside a styled column: trimming it must not drop the reset.
+        let row = "\u{1b}[1;37mCommand   \u{1b}[0m";
+        let trimmed = ansi_trim_end(row);
+        assert!(trimmed.ends_with(ANSI_RESET), "{trimmed:?}");
+        assert_eq!(console::strip_ansi_codes(&trimmed), "Command");
+    }
+
+    #[test]
+    fn test_ansi_trim_end_without_trailing_space_unchanged() {
+        let row = "\u{1b}[1;37mCommand\u{1b}[0m";
+        assert_eq!(ansi_trim_end(row), row);
     }
 }


### PR DESCRIPTION
Fixes #778.

## Root cause

`apply_color` / `apply_style` wrap each column in a style + trailing `\x1b[0m`. `util::truncate()` then cuts the string at the first character that would exceed the target width and returns only what it accumulated so far — everything after the cut point is discarded, **including that trailing reset**.

Both display paths in `view.rs` go through it, back to back:

```rust
row = ansi_trim_end(&row);                        // truncates to drop trailing column padding
row = truncate(&row, self.term_info.width).to_string();  // truncates to terminal width
```

So whenever the last visible column has padding (content shorter than the column) or the row is wider than the terminal, the reset is dropped and the row ends mid-style. That is what leaves the terminal bold/white after `procs` exits, as reported in the issue.

## Fix

Append the reset inside `truncate()` when the retained output contains an escape sequence. Fixing it there covers both call sites rather than only the `ansi_trim_end` one, and plain output is untouched: with `--color=never` (and for `adjust()`, which truncates pre-colorization content) the buffer contains no `\x1b`, so nothing is appended. Un-truncated strings still take the `Cow::Borrowed` path unchanged.

Note this is a different, narrower fix than the earlier self-closed draft #908, which patched only `ansi_trim_end` — that leaves the terminal-width `truncate` on the very next line still able to drop the reset on narrow terminals.

## Verification

Comparing a baseline build (`git stash`) with the fixed build, counting emitted lines that contain ANSI codes but do not end in a reset:

```
                 lines   unreset
base   w=40       270      268
base   w=60       271      269
base   w=120      275      273
fixed  w=40       284        0
fixed  w=60       284        0
fixed  w=120      299        0
```

Header and unit rows are byte-identical after stripping ANSI codes at all three widths, so no visible output changed.

Added four unit tests in `src/util.rs` covering truncation of styled and plain text, and `ansi_trim_end` with and without trailing padding.

```
$ cargo test
test result: ok. 16 passed; 0 failed; 0 ignored

$ cargo fmt --check
(clean)

$ cargo clippy --all-targets -- -D warnings
```

`clippy` output is byte-identical to the `git stash` baseline on this machine — the 12 pre-existing errors are all in macOS-specific code untouched by this change (`unsafe_op_in_unsafe_fn`, `collapsible_if`, etc.).

---

*Written with assistance from Claude Code; reviewed and verified by me before submitting.*