### PR TITLE
Preserve trailing ANSI reset codes in ansi_trim_end

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -226,13 +226,41 @@ pub fn truncate(s: &'_ str, width: usize) -> Cow<'_, str> {
 /// Trim trailing whitespace from a string that may contain ANSI escape sequences.
 /// Unlike str::trim_end(), this correctly handles ANSI codes at the end of the string
 /// that would otherwise prevent trimming of trailing whitespace.
+/// Escape sequences that follow the trimmed whitespace are kept, so a style opened
+/// before the padding is still closed by its reset code.
 pub fn ansi_trim_end(s: &str) -> String {
-    let stripped = console::strip_ansi_codes(s);
-    let trimmed_width = UnicodeWidthStr::width(stripped.trim_end());
-    if trimmed_width == UnicodeWidthStr::width(stripped.as_ref()) {
-        return s.to_string();
+    // (char, whether the char belongs to an ANSI escape sequence)
+    let mut chars: Vec<(char, bool)> = Vec::with_capacity(s.len());
+    let mut escape = false;
+    for c in s.chars() {
+        if c == '\u{1b}' {
+            escape = true;
+        }
+        let in_escape = escape;
+        if escape && c == 'm' {
+            escape = false;
+        }
+        chars.push((c, in_escape));
     }
-    truncate(s, trimmed_width).into_owned()
+
+    let last_visible = chars
+        .iter()
+        .rposition(|(c, in_escape)| !in_escape && !c.is_whitespace());
+
+    match last_visible {
+        Some(last) => chars
+            .iter()
+            .enumerate()
+            .filter(|(i, (_, in_escape))| *i <= last || *in_escape)
+            .map(|(_, (c, _))| c)
+            .collect(),
+        // No visible content: keep the escape sequences only.
+        None => chars
+            .iter()
+            .filter(|(_, in_escape)| *in_escape)
+            .map(|(c, _)| c)
+            .collect(),
+    }
 }
 
 pub fn find_column_kind(pat: &str) -> Option<ConfigColumnKind> {
@@ -381,5 +409,62 @@ pub fn process_new(
         procfs::process::Process::new_with_root(path)
     } else {
         procfs::process::Process::new(pid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ansi_trim_end;
+
+    #[test]
+    fn test_ansi_trim_end_plain() {
+        assert_eq!(ansi_trim_end("abc   "), "abc");
+        assert_eq!(ansi_trim_end("abc"), "abc");
+        assert_eq!(ansi_trim_end("  a b  "), "  a b");
+        assert_eq!(ansi_trim_end(""), "");
+    }
+
+    #[test]
+    fn test_ansi_trim_end_removes_padding_inside_style() {
+        // Padding is inside the styled span, so trim_end() alone cannot see it.
+        assert_eq!(
+            ansi_trim_end("\u{1b}[31mabc   \u{1b}[0m"),
+            "\u{1b}[31mabc\u{1b}[0m"
+        );
+    }
+
+    #[test]
+    fn test_ansi_trim_end_keeps_reset_code() {
+        // The reset must survive trimming, otherwise the style leaks past the line.
+        let trimmed = ansi_trim_end("\u{1b}[31mabc   \u{1b}[0m   ");
+        assert!(!trimmed.ends_with(' '));
+        assert!(trimmed.ends_with("\u{1b}[0m"));
+        assert_eq!(trimmed, "\u{1b}[31mabc\u{1b}[0m");
+    }
+
+    #[test]
+    fn test_ansi_trim_end_multiple_columns() {
+        let row = "\u{1b}[31m1\u{1b}[0m \u{1b}[32m2\u{1b}[0m \u{1b}[33m   \u{1b}[0m";
+        assert_eq!(
+            ansi_trim_end(row),
+            "\u{1b}[31m1\u{1b}[0m \u{1b}[32m2\u{1b}[0m\u{1b}[33m\u{1b}[0m"
+        );
+    }
+
+    #[test]
+    fn test_ansi_trim_end_only_whitespace() {
+        assert_eq!(ansi_trim_end("   "), "");
+        assert_eq!(
+            ansi_trim_end("\u{1b}[31m   \u{1b}[0m"),
+            "\u{1b}[31m\u{1b}[0m"
+        );
+    }
+
+    #[test]
+    fn test_ansi_trim_end_wide_chars() {
+        assert_eq!(
+            ansi_trim_end("\u{1b}[31m\u{2502}あ  \u{1b}[0m"),
+            "\u{1b}[31m\u{2502}あ\u{1b}[0m"
+        );
     }
 }


### PR DESCRIPTION
## Background

While looking into #769 (extraneous trailing spaces with `--color=always`) I found that the reported symptom is already fixed on `master` by bb7d47c (`Fix double-spaced TTY output caused by ANSI-unaware trim_end`, for #848) — colored output no longer has trailing spaces. #769 can probably be closed.

That fix, however, left a related defect behind.

## Problem

`ansi_trim_end()` computes the visible width of the trimmed row and then calls `truncate()` with that width. `truncate()` stops as soon as the width budget is exhausted, so **any escape sequence that sits after the trimmed padding is discarded along with the spaces.**

Rows are assembled by wrapping each padded column in `apply_color()`, which puts the reset code at the very end of the styled span. Trimming therefore removes the reset that closed the last column, leaving an unterminated SGR sequence on every line — the final row's color bleeds into whatever is printed next (typically the shell prompt).

On `master`:

```console
$ procs --color=always zsh | tail -1 | cat -v | tail -c 20
/bin/zsh -l          # <- no ESC[0m; the terminal stays colored afterwards
```

Reduced:

```rust
ansi_trim_end("\x1b[31mabc   \x1b[0m")
// master:   "\x1b[31mabc"        <- reset lost
// expected: "\x1b[31mabc\x1b[0m"
```

## Fix

Trim the trailing whitespace directly rather than routing through `truncate()`, keeping every escape sequence that follows the trimmed run. Behavior for the whitespace itself is unchanged, so the #848/#769 fix is preserved.

## Tests

Adds `src/util.rs` unit tests for `ansi_trim_end`: plain strings, padding inside a styled span, reset-code preservation, multiple styled columns, whitespace-only input, and wide/box-drawing characters.

5 of the 6 fail on `master` and pass with this change:

```
test util::tests::test_ansi_trim_end_keeps_reset_code ... FAILED
test util::tests::test_ansi_trim_end_removes_padding_inside_style ... FAILED
test util::tests::test_ansi_trim_end_multiple_columns ... FAILED
test util::tests::test_ansi_trim_end_only_whitespace ... FAILED
test util::tests::test_ansi_trim_end_wide_chars ... FAILED
```

## Verification

```
$ cargo test
test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo fmt --check
(clean)

$ cargo clippy --all-targets -- -D warnings
14 findings, byte-for-byte the same set as the git-stash baseline
(only line numbers in util.rs shift). No new lint introduced.
```

End-to-end assertion over `procs --color=always` output — 12 lines, 0 with trailing whitespace, 0 with an unterminated SGR sequence.

Tested on macOS (aarch64).

---

*Disclosure: this patch was written with AI assistance (Claude). I reviewed the diff, ran the test/fmt/clippy commands above myself, and isolated the pre-existing clippy findings against a clean baseline.*