### PR TITLE
fix: --json emits invalid JSON when a column is skipped by --only or --tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/dalance/procs/compare/v0.14.12...Unreleased) - ReleaseDate
 
+* [Fixed] Fix invalid JSON output when a column is skipped by --only or --tree
+
 ## [v0.14.12](https://github.com/dalance/procs/compare/v0.14.11...v0.14.12) - 2026-06-25
 
 * [Added] Add fancy regex fallback for advanced filters [#913](https://github.com/dalance/procs/pull/913)

--- a/src/view.rs
+++ b/src/view.rs
@@ -604,18 +604,13 @@ impl View {
 
         let len_pid = self.visible_pids.len();
         for (i, pid) in self.visible_pids.iter().enumerate() {
-            let mut line = "{".to_string();
-            let len_column = self.columns.len();
-            for (j, c) in self.columns.iter().enumerate() {
-                if c.visible && c.kind != ConfigColumnKind::Separator {
-                    let text = c.column.display_json(*pid);
-                    line.push_str(&text);
-                    if j != len_column - 1 {
-                        line.push_str(", ");
-                    }
-                }
-            }
-            line.push('}');
+            let fields: Vec<String> = self
+                .columns
+                .iter()
+                .filter(|c| c.visible && c.kind != ConfigColumnKind::Separator)
+                .map(|c| c.column.display_json(*pid))
+                .collect();
+            let mut line = json_object(&fields);
             if i != len_pid - 1 {
                 line.push(',');
             }
@@ -773,5 +768,36 @@ impl View {
             }
         }
         current
+    }
+}
+
+/// Builds one JSON object row. Columns without a JSON representation
+/// (e.g. Tree) yield an empty string and must not produce a separator.
+fn json_object(fields: &[String]) -> String {
+    let fields: Vec<&str> = fields
+        .iter()
+        .map(String::as_str)
+        .filter(|x| !x.is_empty())
+        .collect();
+    format!("{{{}}}", fields.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::json_object;
+
+    #[test]
+    fn json_object_skips_columns_without_json() {
+        assert_eq!(json_object(&[]), "{}");
+        assert_eq!(json_object(&[r#""PID": 1"#.into()]), r#"{"PID": 1}"#);
+        // a hidden (--only) or Tree column contributes nothing, not a comma
+        assert_eq!(
+            json_object(&["".into(), r#""PID": 1"#.into(), "".into()]),
+            r#"{"PID": 1}"#
+        );
+        assert_eq!(
+            json_object(&[r#""PID": 1"#.into(), r#""CPU": 0"#.into()]),
+            r#"{"PID": 1, "CPU": 0}"#
+        );
     }
 }


### PR DESCRIPTION
## What's broken

`--json` emits invalid JSON whenever a column is skipped, which is what `--only` and `--tree` both do.

```
$ procs --only pid --json
[
{"PID": 1, },
{"PID": 2, },
```

```
$ procs --only pid --json | python3 -c "import sys,json; json.load(sys.stdin)"
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 2 column 12
```

`--tree --json` fails the same way, from the other end:

```
{, "PID": 1, ...}
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 2 column 2
```

Every consumer of `--json` is a program, so this is the one output mode where a stray comma is fatal rather than cosmetic.

## Cause

The separator was decided by position among **all** columns:

```rust
for (j, c) in self.columns.iter().enumerate() {
    if c.visible && c.kind != ConfigColumnKind::Separator {
        line.push_str(&c.column.display_json(*pid));
        if j != len_column - 1 {
            line.push_str(", ");
        }
    }
}
```

while the field itself was only written for visible columns. Two ways to diverge:

- `--only` leaves later columns invisible, so the last **emitted** field is not the last **indexed** one and still gets a trailing `", "`.
- Tree's `display_json` returns an empty string, so the branch runs, writes nothing, and contributes a separator anyway. That one lands at the front, giving `{, "PID": ...`.

#839 fixed the `--only`/`--tree` panic and #763 taught this same loop to skip `Separator` columns, so the shape of the problem is known. What neither touched is the index the comma is keyed on, which is why the invalid output survived both.

## The fix

Collect the fields that are actually emitted, drop the empty ones, and `join(", ")`. A separator can then only appear between two real fields, which is the invariant that was missing.

After, all three modes are valid JSON, and the default `procs --json` is unchanged at the same 227 rows on this machine.

## Verification

A unit test on the new `json_object` helper covering the empty case, one field, a field with empties on both sides, and two fields.

Reverting the change fails it:

```
test view::tests::json_object_skips_columns_without_json ... FAILED
  left: "{, \"PID\": 1, }"
 right: "{\"PID\": 1}"
```

End to end, before and after binaries built from this same checkout, piping each mode through a JSON parser:

```
              --only pid --json      --tree --json        --json
before        JSONDecodeError        JSONDecodeError      valid, 227 rows
after         valid                  valid                valid, 227 rows
```

`cargo test --release` is 14 passed, 0 failed. `cargo clippy` and `cargo fmt --check` are clean.
