### PR TITLE
Detect Docker containers in nested cgroup hierarchies (rootless Docker)

### DIFF
--- a/src/columns/docker.rs
+++ b/src/columns/docker.rs
@@ -94,33 +94,51 @@ impl Docker {
     }
 }
 
+/// Extract a Docker container ID from a cgroup path.
+///
+/// The container's cgroup can be nested at an arbitrary depth: rootful Docker
+/// puts it directly under `/system.slice`, while rootless Docker nests it under
+/// the invoking user's slice. Matching a path *component* rather than a prefix
+/// covers both without enumerating every hierarchy shape.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn container_id_from_cgroup(cgroup_path: &str) -> Option<&str> {
+    fn is_container_id(s: &str) -> bool {
+        s.len() == 64 && s.bytes().all(|b| b.is_ascii_hexdigit())
+    }
+
+    let mut components = cgroup_path.split('/').filter(|x| !x.is_empty()).peekable();
+    while let Some(component) = components.next() {
+        // cgroup v1: `.../docker/<id>`
+        if component == "docker" {
+            if let Some(id) = components.peek().copied().filter(|x| is_container_id(x)) {
+                return Some(id);
+            }
+            continue;
+        }
+        // cgroup v2 with systemd: `.../docker-<id>.scope`
+        if let Some(id) = component
+            .strip_prefix("docker-")
+            .and_then(|x| x.strip_suffix(".scope"))
+            .filter(|x| is_container_id(x))
+        {
+            return Some(id);
+        }
+    }
+    None
+}
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 impl Column for Docker {
     fn add(&mut self, proc: &ProcessInfo) {
         let fmt_content = if let Ok(cgroups) = proc.curr_proc.cgroups() {
             let mut ret = String::new();
             for cgroup in cgroups {
-                let cgroup_name = cgroup.pathname.clone();
-                if cgroup_name.starts_with("/docker") {
-                    let container_id = cgroup_name.replace("/docker/", "");
-                    if let Some(name) = self.containers.get(&container_id) {
-                        ret = name.to_string();
-                        break;
-                    } else {
-                        ret = String::from("?");
-                        break;
-                    }
-                } else if cgroup_name.starts_with("/system.slice/docker-") {
-                    let container_id = cgroup_name
-                        .replace("/system.slice/docker-", "")
-                        .replace(".scope", "");
-                    if let Some(name) = self.containers.get(&container_id) {
-                        ret = name.to_string();
-                        break;
-                    } else {
-                        ret = String::from("?");
-                        break;
-                    }
+                if let Some(container_id) = container_id_from_cgroup(&cgroup.pathname) {
+                    ret = match self.containers.get(container_id) {
+                        Some(name) => name.to_string(),
+                        None => String::from("?"),
+                    };
+                    break;
                 }
             }
             ret
@@ -159,4 +177,51 @@ impl Column for Docker {
     }
 
     column_default!(String, false);
+}
+
+#[cfg(all(test, any(target_os = "linux", target_os = "android")))]
+mod tests {
+    use super::container_id_from_cgroup;
+
+    const ID: &str = "b9fc2a3d3e1c4f5a6b7c8d9e0f1a2b3c4d5e6f708192a3b4c5d6e7f809a1b2c3";
+
+    #[test]
+    fn cgroup_v1() {
+        let path = format!("/docker/{ID}");
+        assert_eq!(container_id_from_cgroup(&path), Some(ID));
+    }
+
+    #[test]
+    fn cgroup_v2_rootful() {
+        let path = format!("/system.slice/docker-{ID}.scope");
+        assert_eq!(container_id_from_cgroup(&path), Some(ID));
+    }
+
+    #[test]
+    fn cgroup_v2_rootless() {
+        let path = format!(
+            "/user.slice/user-1000.slice/user@1000.service/user.slice/docker-{ID}.scope"
+        );
+        assert_eq!(container_id_from_cgroup(&path), Some(ID));
+    }
+
+    #[test]
+    fn non_container_cgroups() {
+        for path in [
+            "/",
+            "/init.scope",
+            "/system.slice/docker.service",
+            "/system.slice/containerd.service",
+            "/user.slice/user-1000.slice/user@1000.service/app.slice/docker-desktop.scope",
+            "/docker/not-a-container-id",
+        ] {
+            assert_eq!(container_id_from_cgroup(path), None, "path: {path}");
+        }
+    }
+
+    #[test]
+    fn id_must_be_a_whole_component() {
+        let path = format!("/system.slice/prefix-docker-{ID}.scope");
+        assert_eq!(container_id_from_cgroup(&path), None);
+    }
 }


### PR DESCRIPTION
## Problem

The `Docker` column identifies a process's container by matching its cgroup path with two hard-coded prefixes:

```rust
if cgroup_name.starts_with("/docker") { ... }
else if cgroup_name.starts_with("/system.slice/docker-") { ... }
```

This assumes the container's cgroup sits at a fixed place in the hierarchy. That holds for cgroup v1 (`/docker/<id>`) and for rootful, systemd-managed Docker on cgroup v2 (`/system.slice/docker-<id>.scope`), but **rootless Docker** nests the container scope under the invoking user's slice:

```
/user.slice/user-1000.slice/user@1000.service/user.slice/docker-<64-hex-id>.scope
```

Neither branch matches, so the `Docker` column is silently empty for rootless Docker users even though the container ID is right there in the path.

## Fix

Search for a container cgroup *component* at any depth rather than requiring a specific prefix:

- `docker-<id>.scope` as a whole path component (rootful and rootless cgroup v2, and any other nesting)
- `docker` followed by `<id>` (cgroup v1, including nested variants)

To avoid becoming too permissive, the ID must be a complete component of exactly 64 hex digits — which is the form Docker container IDs take, and the form of the keys in the container-ID→name map this value is looked up in. So `docker.service`, `docker-desktop.scope`, and `prefix-docker-<id>.scope` are not matched.

The extraction is pulled out into a standalone `container_id_from_cgroup` function so it can be unit-tested directly. Behaviour for rootful Docker is unchanged.

## Tests

Five unit tests added in `src/columns/docker.rs` covering cgroup v1, cgroup v2 rootful (existing behaviour), cgroup v2 rootless (the fix), a set of non-container cgroup paths, and a guard that the ID must be a whole path component.

## Verification

Because the affected code is `#[cfg(any(target_os = "linux", target_os = "android"))]`, it was checked against the Linux target from a macOS host:

```
$ cargo fmt --check                                                        # clean
$ cargo clippy --target x86_64-unknown-linux-gnu --all-targets -- -D warnings
error: you seem to want to iterate on a map's values --> src/main.rs:191:24
```

That one lint is pre-existing — it reproduces identically on an unmodified checkout (verified via `git stash`), and this change introduces no new clippy findings.

The new tests were executed by temporarily relaxing the `cfg` gate so the parsing function (pure string logic, platform-independent) builds on the host:

```
running 5 tests
.....
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out
```

I do not have a Linux machine with rootless Docker to hand, so the end-to-end behaviour is verified by the unit tests against the documented cgroup path shape rather than against a live rootless daemon. Happy to adjust if the maintainers' rootless setups produce a different path.

---

*Disclosure: this change was written with AI assistance (Claude). It has been reviewed by me before submission.*
