### PR TITLE
ci: add native Windows ARM64 release artifacts

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -23,6 +23,9 @@ jobs:
           - os: windows-latest
             rust: stable
             target: x86_64-pc-windows-msvc
+          - os: windows-11-arm
+            rust: stable
+            target: aarch64-pc-windows-msvc
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macOS-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macOS-latest, windows-latest, windows-11-arm]
         rust: [stable]
 
     runs-on: ${{ matrix.os }}
@@ -52,6 +52,9 @@ jobs:
     - name: Build for Windows
       if: matrix.os == 'windows-latest'
       run: make release_win
+    - name: Build for Windows ARM64
+      if: matrix.os == 'windows-11-arm'
+      run: make release_win_arm64
     - name: Release
       uses: softprops/action-gh-release@v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ BIN_NAME = procs
 
 export LONG_VERSION
 
-.PHONY: all test clean release_lnx release_win release_mac
+.PHONY: all test clean release_lnx release_win release_win_arm64 release_mac
 
 all: test
 
@@ -32,6 +32,11 @@ release_win:
 	cargo build --locked --release --target=x86_64-pc-windows-msvc
 	mv -v target/x86_64-pc-windows-msvc/release/${BIN_NAME}.exe ./
 	7z a ${BIN_NAME}-v${VERSION}-x86_64-windows.zip ${BIN_NAME}.exe
+
+release_win_arm64:
+	cargo build --locked --release --target=aarch64-pc-windows-msvc
+	mv -v target/aarch64-pc-windows-msvc/release/${BIN_NAME}.exe ./
+	7z a ${BIN_NAME}-v${VERSION}-aarch64-windows.zip ${BIN_NAME}.exe
 
 release_mac:
 	cargo build --locked --release --target=x86_64-apple-darwin


### PR DESCRIPTION
Add native Windows ARM64 regression coverage and a matching release artifact.

- Test `aarch64-pc-windows-msvc` on GitHub-hosted `windows-11-arm`.
- Build and package `procs-v<version>-aarch64-windows.zip` in the release
  workflow.

The new native ARM64 build job passed in the fork:
https://github.com/meop/procs/actions/runs/33223440730/job/99022194932

The current upstream clippy failure is pre-existing: it flags the existing
`for_kv_map` lint and is unrelated to this change.
