### PR TITLE
Add show_kthreads support on FreeBSD

### DIFF
--- a/src/process/freebsd.rs
+++ b/src/process/freebsd.rs
@@ -15,7 +15,7 @@ pub struct ProcessInfo {
 pub fn collect_proc(
     interval: Duration,
     _with_thread: bool,
-    _show_kthreads: bool,
+    show_kthreads: bool,
     _procfs_path: &Option<PathBuf>,
 ) -> Vec<ProcessInfo> {
     let mut base_procs = HashMap::new();
@@ -24,6 +24,10 @@ pub fn collect_proc(
     let kvm = Kvm::open(None, Some("/dev/null"), Access::ReadOnly);
     if let Ok(mut kvm) = kvm {
         for proc in kvm.get_process(KernProc::Proc, 0) {
+            if !show_kthreads && proc.info.flag & 0x00000004 /* P_KPROC */ != 0 {
+                continue;
+            }
+
             let time = Instant::now();
             base_procs.insert(proc.info.pid, (proc.clone(), time));
         }


### PR DESCRIPTION
Before (show_kthread = true)

<img width="2382" height="1408" alt="image" src="https://github.com/user-attachments/assets/670b40cc-5f47-4da6-9880-0d2cc634d4b6" />

After (show_kthread = false)

<img width="2382" height="1408" alt="image" src="https://github.com/user-attachments/assets/1e9c5a31-3d63-44dd-9499-42f3dc225c34" />

Tested on FreeBSD 15.1

```
$ uname -a
FreeBSD freebsd-pc 15.1-RELEASE-p2 FreeBSD 15.1-RELEASE-p2 releng/15.1-n283596-aadd58dddcbc GENERIC amd64
```