### PR TITLE
support `show_kthreads` on macOS

### DIFF
--- a/src/process/macos.rs
+++ b/src/process/macos.rs
@@ -30,7 +30,7 @@ pub struct ProcessInfo {
 pub fn collect_proc(
     interval: Duration,
     _with_thread: bool,
-    _show_kthreads: bool,
+    show_kthreads: bool,
     _procfs_path: &Option<PathBuf>,
 ) -> Vec<ProcessInfo> {
     let mut base_procs = Vec::new();
@@ -40,6 +40,10 @@ pub fn collect_proc(
     if let Ok(procs) = pids_by_type(ProcFilter::All) {
         for p in procs {
             if let Ok(task) = pidinfo::<TaskAllInfo>(p as i32, 0) {
+                if !show_kthreads && task.pbsd.pbi_flags & 1 /* PROC_FLAG_SYSTEM */ != 0 {
+                    continue;
+                }
+
                 let res = pidrusage::<RUsageInfoV2>(p as i32).ok();
                 let time = Instant::now();
                 base_procs.push((p as i32, task, res, time));


### PR DESCRIPTION
Currently only PID 0 is marked as kthread

Before (show_kthread = true, running with sudo)

<img width="761" height="578" alt="image" src="https://github.com/user-attachments/assets/11b24eb7-0f38-48a1-adff-b462db23ff1b" />

After (show_kthread = false, running with sudo)

<img width="1510" height="1108" alt="image" src="https://github.com/user-attachments/assets/06ab7dd6-b884-4eec-8c1f-c8ea8015d33b" />

