### PR TITLE
Windows: rewrite process enumeration around NtQuerySystemInformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,19 @@
 
 ## [Unreleased](https://github.com/dalance/procs/compare/v0.14.12...Unreleased) - ReleaseDate
 
-* [Fixed] Fix invalid JSON output when a column is skipped by --only or --tree
+* [Added] Arch column for Windows (process image architecture)
+* [Added] Real Command column for Windows (command line arguments). This column was printing pure file name, which is now moved to FileName column.
+* [Added] Priority column for Windows (user-mode priority class)
+* [Added] RtPriority column for Windows (kernel base priority)
+* [Added] Threads column for Windows (thread count)
+* [Added] Session column for Windows (session ID)
+* [Added] State column for Windows (scheduler state derived from thread states)
+* [Added] Env column for Windows (environment variables)
+* [Added] RecvBytes and SendBytes columns for Windows (network I/O rate; needs Windows 11 or later)
+* [Added] WorkDir column for Windows (current working directory)
+* [Added] `--thread` support for Windows
 * [Fixed] ReadBytes / WriteBytes divided by a mis-scaled interval (seconds added to milliseconds)
+* [Fixed] Fix invalid JSON output when a column is skipped by --only or --tree
 
 ## [v0.14.12](https://github.com/dalance/procs/compare/v0.14.11...v0.14.12) - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [Added] RecvBytes and SendBytes columns for Windows (network I/O rate; needs Windows 11 or later)
 * [Added] WorkDir column for Windows (current working directory)
 * [Added] `--thread` support for Windows
+* [Changed] Group and Gid columns for Windows read the process token only when the column is displayed
 * [Fixed] ReadBytes / WriteBytes divided by a mis-scaled interval (seconds added to milliseconds)
 * [Fixed] Fix invalid JSON output when a column is skipped by --only or --tree
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ which         = "8"
 mach2         = "0.7.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys   = { version = "0.61", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Security", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Threading"] }
+windows-sys   = { version = "0.61", features = ["Wdk_System_SystemInformation", "Wdk_System_SystemServices", "Wdk_System_Threading", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Security", "Win32_System_Diagnostics_Debug", "Win32_System_Kernel", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 bsd-kvm       = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ which         = "8"
 mach2         = "0.7.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys   = { version = "0.61", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Security", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_ProcessStatus", "Win32_System_Threading"] }
+windows-sys   = { version = "0.61", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Security", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_Threading"] }
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 bsd-kvm       = "0.1.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ which         = "8"
 mach2         = "0.7.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys   = { version = "0.61", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Security", "Win32_System_Diagnostics_ToolHelp", "Win32_System_ProcessStatus", "Win32_System_Threading"] }
+windows-sys   = { version = "0.61", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_NetworkManagement_IpHelper", "Win32_Security", "Win32_System_Diagnostics_Debug", "Win32_System_LibraryLoader", "Win32_System_ProcessStatus", "Win32_System_Threading"] }
 
 [target.'cfg(target_os = "freebsd")'.dependencies]
 bsd-kvm       = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ The first `[[columns]]` is shown at left side, and the last is shown at right si
 
 | procs `kind`         | `ps` STANDARD FORMAT  | Description                                   | Linux | macOS | Windows | FreeBSD |
 | -------------------- | --------------------- | --------------------------------------------- | ----- | ----- | ------- | ------- |
-| Arch                 | -not supported-       | Architecture of binary (macOS specific)       |       | o     |         |         |
+| Arch                 | -not supported-       | Architecture of binary                        |       | o     | o       |         |
 | Ccgroup              | -not supported-       | Control group by compressed format            | o     |       |         |         |
 | Cgroup               | cgroup                | Control group                                 | o     |       |         |         |
 | Command              | args                  | Command with all arguments                    | o     | o     | o       | o       |

--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ The first `[[columns]]` is shown at left side, and the last is shown at right si
 | ElapsedTime          | -not supported-       | Elapsed time                                  | o     | o     | o       | o       |
 | Env                  | `e` output modifier   | Environment variables                         | o     |       |         | o       |
 | Esp                  | esp                   | Stack pointer                                 | o     |       |         |         |
-| FileName             | comm                  | File name                                     | o     |       |         | o       |
+| FileName             | comm                  | File name                                     | o     |       | o       | o       |
 | Gid                  | egid                  | Group ID                                      | o     | o     | o       | o       |
 | GidFs                | fgid                  | File system group ID                          | o     |       |         |         |
 | GidReal              | rgid                  | Real group ID                                 | o     | o     |         | o       |
@@ -469,7 +469,7 @@ The first `[[columns]]` is shown at left side, and the last is shown at right si
 | RtPriority           | rtprio                | Kernel base priority (Windows) / real-time priority (Linux) | o     |       | o       |         |
 | SecContext           | label                 | Security context                              | o     |       |         |         |
 | Separator            | -not supported-       | Show `\|` for column separation               | o     | o     | o       | o       |
-| Session              | sid                   | Session ID                                    | o     | o     |         | o       |
+| Session              | sid                   | Session ID                                    | o     | o     | o       | o       |
 | ShdPnd               | pending               | Pending signal mask for process               | o     |       |         | o       |
 | SigBlk               | blocked               | Blocked signal mask                           | o     |       |         | o       |
 | SigCgt               | caught                | Caught signal mask                            | o     |       |         | o       |
@@ -479,8 +479,8 @@ The first `[[columns]]` is shown at left side, and the last is shown at right si
 | Ssb                  | -not supported-       | Speculative store bypass status               | o     |       |         |         |
 | StartTime            | start_time            | Starting time                                 | o     | o     | o       | o       |
 | State                | s                     | Process state                                 | o     | o     |         | o       |
-| TcpPort              | -not supported-       | Bound TCP ports                               | o     | o     |         |         |
-| Threads              | nlwp                  | Thread count                                  | o     | o     |         | o       |
+| TcpPort              | -not supported-       | Bound TCP ports                               | o     | o     | o       |         |
+| Threads              | nlwp                  | Thread count                                  | o     | o     | o       | o       |
 | TreeSlot             | -not supported-       | Slot for tree column                          | o     | o     | o       | o       |
 | Tty                  | tty                   | Controlling TTY                               | o     | o     |         | o       |
 | UdpPort              | -not supported-       | Bound UDP ports                               | o     | o     |         |         |

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ The first `[[columns]]` is shown at left side, and the last is shown at right si
 | Priority             | pri                   | Priority                                      | o     | o     | o       | o       |
 | Processor            | psr                   | Currently assigned processor                  | o     |       |         | o       |
 | ReadBytes            | -not supported-       | Read bytes from storage                       | o     | o     | o       | o       |
-| RtPriority           | rtprio                | Real-time priority                            | o     |       |         |         |
+| RtPriority           | rtprio                | Kernel base priority (Windows) / real-time priority (Linux) | o     |       | o       |         |
 | SecContext           | label                 | Security context                              | o     |       |         |         |
 | Separator            | -not supported-       | Show `\|` for column separation               | o     | o     | o       | o       |
 | Session              | sid                   | Session ID                                    | o     | o     |         | o       |

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ The first `[[columns]]` is shown at left side, and the last is shown at right si
 | Slot                 | -not supported-       | Slot for `--insert` option                    | o     | o     | o       | o       |
 | Ssb                  | -not supported-       | Speculative store bypass status               | o     |       |         |         |
 | StartTime            | start_time            | Starting time                                 | o     | o     | o       | o       |
-| State                | s                     | Process state                                 | o     | o     |         | o       |
+| State                | s                     | Process state                                 | o     | o     | o       | o       |
 | TcpPort              | -not supported-       | Bound TCP ports                               | o     | o     | o       |         |
 | Threads              | nlwp                  | Thread count                                  | o     | o     | o       | o       |
 | TreeSlot             | -not supported-       | Slot for tree column                          | o     | o     | o       | o       |

--- a/README.md
+++ b/README.md
@@ -466,8 +466,10 @@ The first `[[columns]]` is shown at left side, and the last is shown at right si
 | Priority             | pri                   | Priority                                      | o     | o     | o       | o       |
 | Processor            | psr                   | Currently assigned processor                  | o     |       |         | o       |
 | ReadBytes            | -not supported-       | Read bytes from storage                       | o     | o     | o       | o       |
+| RecvBytes            | -not supported-       | Received bytes per second (Windows 11)        |       |       | o       |         |
 | RtPriority           | rtprio                | Kernel base priority (Windows) / real-time priority (Linux) | o     |       | o       |         |
 | SecContext           | label                 | Security context                              | o     |       |         |         |
+| SendBytes            | -not supported-       | Sent bytes per second (Windows 11)            |       |       | o       |         |
 | Separator            | -not supported-       | Show `\|` for column separation               | o     | o     | o       | o       |
 | Session              | sid                   | Session ID                                    | o     | o     | o       | o       |
 | ShdPnd               | pending               | Pending signal mask for process               | o     |       |         | o       |
@@ -511,7 +513,7 @@ The first `[[columns]]` is shown at left side, and the last is shown at right si
 | VmTotal              | -not supported-       | Total virtual memory size                     | *[^*] | o     | *[^*]   | *[^*]   |
 | VoluntaryContextSw   | -not supported-       | Voluntary context switch count                | o     |       |         | o       |
 | Wchan                | wchan                 | Process sleeping kernel function              | o     |       |         | o       |
-| WorkDir              | -not supported-       | Current working directory                     | o     |       |         |         |
+| WorkDir              | -not supported-       | Current working directory                     | o     |       | o       |         |
 | WriteByte            | -not supported-       | Write bytes to storage                        | o     | o     | o       | o       |
 
 [^*]: Alias for VmRss on these platforms

--- a/src/columns/arch.rs
+++ b/src/columns/arch.rs
@@ -3,9 +3,13 @@ use crate::{column_default, Column};
 use std::cmp;
 use std::collections::HashMap;
 
+#[cfg(target_os = "macos")]
 const CTL_MAXNAME: i32 = 12;
+#[cfg(target_os = "macos")]
 const P_TRANSLATED: i32 = 131072;
+#[cfg(target_os = "macos")]
 const CPU_TYPE_X86_64: i32 = 16777223;
+#[cfg(target_os = "macos")]
 const CPU_TYPE_ARM64: i32 = 16777228;
 
 pub struct Arch {
@@ -16,7 +20,6 @@ pub struct Arch {
     width: usize,
 }
 
-#[cfg(target_os = "macos")]
 impl Arch {
     pub fn new(header: Option<String>) -> Self {
         let header = header.unwrap_or_else(|| String::from("Arch"));
@@ -31,13 +34,12 @@ impl Arch {
     }
 }
 
-#[cfg(target_os = "macos")]
 impl Column for Arch {
     fn add(&mut self, proc: &ProcessInfo) {
         let pid = proc.pid;
         let arch = arch_from_pid(pid);
 
-        let fmt_content = format!("{}", arch);
+        let fmt_content = arch.to_string();
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);
@@ -46,6 +48,116 @@ impl Column for Arch {
 
     column_default!(String, false);
 }
+
+// ---------------------------------------------------------------------------
+// Windows
+// ---------------------------------------------------------------------------
+
+/// `IMAGE_FILE_MACHINE_*` constants.
+///
+/// <https://learn.microsoft.com/zh-cn/windows/win32/sysinfo/image-file-machine-constants>
+#[cfg(target_os = "windows")]
+mod machine {
+    pub const UNKNOWN: u16 = 0x0000;
+    pub const ALPHA: u16 = 0x0184;
+    /// Same value as `IMAGE_FILE_MACHINE_AXP64`.
+    pub const ALPHA64: u16 = 0x0284;
+    pub const AM33: u16 = 0x01d3;
+    pub const AMD64: u16 = 0x8664;
+    pub const ARM: u16 = 0x01c0;
+    pub const ARM64: u16 = 0xaa64;
+    /// x86_64 code that runs on ARM64 through emulation.
+    pub const ARM64EC: u16 = 0xa641;
+    /// Image loadable both as ARM64 and as ARM64EC.
+    pub const ARM64X: u16 = 0xa64e;
+    /// ARMv7 / Thumb-2; `IMAGE_FILE_MACHINE_ARMV7` shares this value.
+    pub const ARMNT: u16 = 0x01c4;
+    pub const CEE: u16 = 0xc0ee;
+    pub const CEF: u16 = 0x0cef;
+    pub const EBC: u16 = 0x0ebc;
+    pub const I386: u16 = 0x014c;
+    pub const IA64: u16 = 0x0200;
+    pub const M32R: u16 = 0x9041;
+    pub const MIPS16: u16 = 0x0266;
+    pub const MIPSFPU: u16 = 0x0366;
+    pub const MIPSFPU16: u16 = 0x0466;
+    pub const POWERPC: u16 = 0x01f0;
+    pub const POWERPCFP: u16 = 0x01f1;
+    pub const R3000: u16 = 0x0162;
+    pub const R4000: u16 = 0x0166;
+    pub const R10000: u16 = 0x0168;
+    pub const SH3: u16 = 0x01a2;
+    pub const SH3DSP: u16 = 0x01a3;
+    pub const SH3E: u16 = 0x01a4;
+    pub const SH4: u16 = 0x01a6;
+    pub const SH5: u16 = 0x01a8;
+    pub const THUMB: u16 = 0x01c2;
+    pub const TRICORE: u16 = 0x0520;
+    pub const WCEMIPSV2: u16 = 0x0169;
+}
+
+/// Reports the architecture of the image `pid` was started from.
+///
+/// WOW64 processes report their own architecture, not the host's: a 32-bit
+/// process on an x86_64 machine yields `x86`.
+#[cfg(target_os = "windows")]
+pub fn arch_from_pid(pid: i32) -> &'static str {
+    use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE};
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+
+    // 0 is the idle process and has no image; negative pids are not real.
+    if pid <= 0 {
+        return "unknown";
+    }
+
+    // SAFETY: `pid` is only handed to `OpenProcess`, and the handle it hands
+    // back is closed before this function returns.
+    let handle: HANDLE = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid as u32) };
+    if handle.is_null() {
+        return "unknown";
+    }
+
+    let arch = crate::process::process_image_machine(handle)
+        .map(arch_from_machine)
+        .unwrap_or("unknown");
+    unsafe { CloseHandle(handle) };
+
+    arch
+}
+
+/// Names an `IMAGE_FILE_MACHINE_*` value the way the rest of the crate spells
+/// architectures (`x86_64`, `arm64`, ...).
+#[cfg(target_os = "windows")]
+fn arch_from_machine(machine: u16) -> &'static str {
+    use machine::*;
+
+    match machine {
+        UNKNOWN => "unknown",
+        I386 => "x86",
+        AMD64 => "x86_64",
+        ARM | ARMNT | THUMB => "arm",
+        ARM64 => "arm64",
+        ARM64EC => "arm64ec",
+        ARM64X => "arm64x",
+        IA64 => "ia64",
+        EBC => "ebc",
+        ALPHA | ALPHA64 => "alpha",
+        MIPS16 | MIPSFPU | MIPSFPU16 | R3000 | R4000 | R10000 | WCEMIPSV2 => "mips",
+        POWERPC | POWERPCFP => "ppc",
+        SH3 | SH3DSP | SH3E | SH4 | SH5 => "sh",
+        M32R => "m32r",
+        AM33 => "am33",
+        TRICORE => "tricore",
+        CEF => "cef",
+        // Pure IL assembly: no architecture of its own.
+        CEE => "msil",
+        _ => "unknown",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// macOS
+// ---------------------------------------------------------------------------
 
 #[cfg(target_os = "macos")]
 pub fn arch_from_pid(pid: i32) -> &'static str {
@@ -97,4 +209,23 @@ pub fn arch_from_pid(pid: i32) -> &'static str {
     }
 
     "unknown"
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::{arch_from_machine, machine};
+
+    #[test]
+    fn machine_names() {
+        assert_eq!(arch_from_machine(machine::AMD64), "x86_64");
+        assert_eq!(arch_from_machine(machine::I386), "x86");
+        assert_eq!(arch_from_machine(machine::ARM64), "arm64");
+        assert_eq!(arch_from_machine(machine::ARM64EC), "arm64ec");
+        // ARMv7 and Thumb-2 are both 32-bit ARM.
+        assert_eq!(arch_from_machine(machine::ARMNT), "arm");
+        assert_eq!(arch_from_machine(machine::THUMB), "arm");
+        // No image, and a value outside the table.
+        assert_eq!(arch_from_machine(machine::UNKNOWN), "unknown");
+        assert_eq!(arch_from_machine(0x1234), "unknown");
+    }
 }

--- a/src/columns/command.rs
+++ b/src/columns/command.rs
@@ -91,7 +91,14 @@ impl Column for Command {
 #[cfg(target_os = "windows")]
 impl Column for Command {
     fn add(&mut self, proc: &ProcessInfo) {
-        let fmt_content = proc.command.clone();
+        // Show the command line when present, otherwise fall back to the image
+        // name (e.g. System, Idle, or protected processes with no command line).
+        let fmt_content = proc
+            .command
+            .as_ref()
+            .filter(|c| !c.is_empty())
+            .cloned()
+            .unwrap_or_else(|| proc.file_name.clone());
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);

--- a/src/columns/env.rs
+++ b/src/columns/env.rs
@@ -4,6 +4,9 @@ use std::cmp;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::Foundation::HANDLE;
+
 pub struct Env {
     header: String,
     unit: String,
@@ -67,4 +70,160 @@ impl Column for Env {
     }
 
     column_default!(String, false);
+}
+
+#[cfg(target_os = "windows")]
+impl Column for Env {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let fmt_content = env_of(proc.pid).unwrap_or_default();
+        let raw_content = fmt_content.clone();
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(String, false);
+}
+
+/// Reads the environment block of `pid` from its PEB.
+///
+/// The PEB address comes from `NtQueryInformationProcess` with
+/// `ProcessBasicInformation`; the PEB, the process parameters it points at
+/// and the environment block are then read with `ReadProcessMemory`. Needs
+/// `PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ`, so protected
+/// processes (e.g. PPL) yield `None`.
+#[cfg(target_os = "windows")]
+fn env_of(pid: i32) -> Option<String> {
+    use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_VM_READ,
+    };
+
+    // 0 is the idle process and has no PEB; negative pids are not real.
+    if pid <= 0 {
+        return None;
+    }
+
+    // SAFETY: `pid` is only handed to `OpenProcess`, and the handle it returns
+    // is closed before this function returns.
+    let handle: HANDLE = unsafe {
+        OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ,
+            FALSE,
+            pid as u32,
+        )
+    };
+    if handle.is_null() {
+        return None;
+    }
+
+    let env = read_env(handle);
+    unsafe { CloseHandle(handle) };
+    env
+}
+
+/// Reads the environment block out of the PEB of `handle` and formats it
+/// like the Linux column (`KEY="VALUE" ` per entry).
+#[cfg(target_os = "windows")]
+fn read_env(handle: HANDLE) -> Option<String> {
+    use crate::process::{
+        process_peb_address, read_process_memory, PEB_PREFIX,
+        RTL_USER_PROCESS_PARAMETERS_PREFIX,
+    };
+    use std::mem::{offset_of, size_of};
+
+    // The PEB address lives in the target's address space.
+    let peb = process_peb_address(handle)?;
+
+    // Read the leading PEB fields. `ProcessParameters` sits within the first
+    // page, so a single read covers it.
+    let mut peb_buf = [0u64; 0x100 / size_of::<u64>()];
+    read_process_memory(handle, peb, &mut peb_buf)?;
+
+    // SAFETY: `peb_buf` is 8-byte aligned and `ProcessParameters` is a
+    // pointer-sized field at a pointer-aligned offset, so the read is aligned.
+    let params_addr = unsafe {
+        peb_buf
+            .as_ptr()
+            .cast::<u8>()
+            .add(offset_of!(PEB_PREFIX, ProcessParameters))
+            .cast::<usize>()
+            .read()
+    };
+    // A 32-bit address from a 64-bit reader means a WOW64 process, whose
+    // process parameters use the 32-bit layout; refuse rather than misparse.
+    if params_addr == 0 || (size_of::<usize>() == 8 && params_addr >> 32 == 0) {
+        return None;
+    }
+
+    // Read the leading process-parameters fields. `Environment` sits within
+    // the first page, but `EnvironmentSize` sits at 0x3F0 (64-bit) / 0x290
+    // (32-bit), so the buffer must be sized to cover it.
+    let mut params_buf = [0u64; 0x400 / size_of::<u64>()];
+    read_process_memory(handle, params_addr, &mut params_buf)?;
+
+    // SAFETY: `params_buf` is 8-byte aligned and `Environment` is a
+    // pointer-sized field at a pointer-aligned offset, so the read is aligned.
+    let env_addr = unsafe {
+        params_buf
+            .as_ptr()
+            .cast::<u8>()
+            .add(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, Environment))
+            .cast::<usize>()
+            .read()
+    };
+    if env_addr == 0 || (size_of::<usize>() == 8 && env_addr >> 32 == 0) {
+        return None;
+    }
+
+    // `EnvironmentSize` is the byte size of the block, including the final
+    // double-NUL terminator. It is a `ULONG_PTR`, so it is pointer-sized.
+    let env_size = unsafe {
+        params_buf
+            .as_ptr()
+            .cast::<u8>()
+            .add(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, EnvironmentSize))
+            .cast::<usize>()
+            .read()
+    };
+    if env_size == 0 || env_size > MAX_ENV_BYTES {
+        return None;
+    }
+
+    // The block lives in the target's address space, so it needs its own read.
+    let mut chars = vec![0u16; env_size.div_ceil(2)];
+    read_process_memory(handle, env_addr, &mut chars)?;
+
+    Some(format_env_block(&chars))
+}
+
+/// Guard against a nonsensical `EnvironmentSize` turning into a huge
+/// allocation. Real environment blocks are capped well below this.
+#[cfg(target_os = "windows")]
+const MAX_ENV_BYTES: usize = 64 * 1024;
+
+/// Formats a raw environment block like the Linux column:
+/// `KEY="VALUE" ` for each entry, with embedded quotes escaped.
+#[cfg(target_os = "windows")]
+fn format_env_block(block: &[u16]) -> String {
+    let mut out = String::new();
+    let mut start = 0usize;
+    for i in 0..block.len() {
+        if block[i] == 0 {
+            if i == start {
+                break; // double NUL: end of block
+            }
+            let entry = String::from_utf16_lossy(&block[start..i]);
+            if let Some(eq) = entry.find('=') {
+                let (key, value) = entry.split_at(eq);
+                out.push_str(&format!(
+                    "{}=\"{}\" ",
+                    key,
+                    value[1..].replace('"', "\\\"")
+                ));
+            }
+            start = i + 1;
+        }
+    }
+    out
 }

--- a/src/columns/file_name.rs
+++ b/src/columns/file_name.rs
@@ -38,6 +38,19 @@ impl Column for FileName {
     column_default!(String, false);
 }
 
+#[cfg(target_os = "windows")]
+impl Column for FileName {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let raw_content = proc.file_name.clone();
+        let fmt_content = raw_content.clone();
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(String, false);
+}
+
 #[cfg(target_os = "freebsd")]
 impl Column for FileName {
     fn add(&mut self, proc: &ProcessInfo) {

--- a/src/columns/gid.rs
+++ b/src/columns/gid.rs
@@ -64,7 +64,16 @@ impl Column for Gid {
 #[cfg(target_os = "windows")]
 impl Column for Gid {
     fn add(&mut self, proc: &ProcessInfo) {
-        let mut sid = &proc.groups[0].sid;
+        // A process whose token could not be opened - a protected process, or
+        // any process when procs is not elevated - has no group list. Render
+        // nothing rather than indexing a non-existent primary group.
+        let Some(primary) = proc.groups.first() else {
+            self.fmt_contents.insert(proc.pid, String::new());
+            self.raw_contents.insert(proc.pid, 0);
+            return;
+        };
+
+        let mut sid = &primary.sid;
         let mut kind = u64::MAX;
         for g in &proc.groups {
             if g.sid.len() > 3 && g.sid[1] == 5 && g.sid[2] == 32 && kind > g.sid[3] {

--- a/src/columns/gid.rs
+++ b/src/columns/gid.rs
@@ -1,6 +1,4 @@
 use crate::process::ProcessInfo;
-#[cfg(target_os = "windows")]
-use crate::util::format_sid;
 use crate::{column_default, Column};
 use std::cmp;
 use std::collections::HashMap;
@@ -73,17 +71,21 @@ impl Column for Gid {
             return;
         };
 
-        let mut sid = &primary.sid;
+        let mut sid = primary;
         let mut kind = u64::MAX;
         for g in &proc.groups {
-            if g.sid.len() > 3 && g.sid[1] == 5 && g.sid[2] == 32 && kind > g.sid[3] {
-                sid = &g.sid;
-                kind = g.sid[3];
+            let subs = g.sub_authorities();
+            if g.authority() == 5
+                && subs.first() == Some(&32)
+                && u64::from(subs.get(1).copied().unwrap_or(u32::MAX)) < kind
+            {
+                sid = g;
+                kind = u64::from(subs[1]);
             }
         }
 
-        let fmt_content = format_sid(sid, self.abbr_sid);
-        let raw_content = sid[sid.len() - 1] as u32;
+        let fmt_content = sid.format(self.abbr_sid);
+        let raw_content = sid.sub_authorities().last().copied().unwrap_or(0);
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);

--- a/src/columns/gid.rs
+++ b/src/columns/gid.rs
@@ -1,5 +1,7 @@
 use crate::process::ProcessInfo;
 use crate::{column_default, Column};
+#[cfg(target_os = "windows")]
+use crate::columns::group::{groups_of, primary_group};
 use std::cmp;
 use std::collections::HashMap;
 
@@ -62,30 +64,17 @@ impl Column for Gid {
 #[cfg(target_os = "windows")]
 impl Column for Gid {
     fn add(&mut self, proc: &ProcessInfo) {
-        // A process whose token could not be opened - a protected process, or
-        // any process when procs is not elevated - has no group list. Render
-        // nothing rather than indexing a non-existent primary group.
-        let Some(primary) = proc.groups.first() else {
-            self.fmt_contents.insert(proc.pid, String::new());
-            self.raw_contents.insert(proc.pid, 0);
-            return;
+        // Same on-demand lookup as `Group`: a process whose token could not be
+        // opened - a protected process, or any process when procs is not
+        // elevated - has no group list and renders as nothing.
+        let (fmt_content, raw_content) = match groups_of(proc.pid).as_deref().and_then(primary_group)
+        {
+            Some(sid) => (
+                sid.format(self.abbr_sid),
+                sid.sub_authorities().last().copied().unwrap_or(0),
+            ),
+            None => (String::new(), 0),
         };
-
-        let mut sid = primary;
-        let mut kind = u64::MAX;
-        for g in &proc.groups {
-            let subs = g.sub_authorities();
-            if g.authority() == 5
-                && subs.first() == Some(&32)
-                && u64::from(subs.get(1).copied().unwrap_or(u32::MAX)) < kind
-            {
-                sid = g;
-                kind = u64::from(subs[1]);
-            }
-        }
-
-        let fmt_content = sid.format(self.abbr_sid);
-        let raw_content = sid.sub_authorities().last().copied().unwrap_or(0);
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);

--- a/src/columns/group.rs
+++ b/src/columns/group.rs
@@ -78,7 +78,16 @@ impl Column for Group {
 #[cfg(target_os = "windows")]
 impl Column for Group {
     fn add(&mut self, proc: &ProcessInfo) {
-        let mut sid_name = &proc.groups[0];
+        // A process whose token could not be opened - a protected process, or
+        // any process when procs is not elevated - has no group list. Render
+        // nothing rather than indexing a non-existent primary group.
+        let Some(primary) = proc.groups.first() else {
+            self.fmt_contents.insert(proc.pid, String::new());
+            self.raw_contents.insert(proc.pid, String::new());
+            return;
+        };
+
+        let mut sid_name = primary;
         let mut kind = u64::MAX;
         for g in &proc.groups {
             if g.sid.len() > 3 && g.sid[1] == 5 && g.sid[2] == 32 && kind > g.sid[3] {

--- a/src/columns/group.rs
+++ b/src/columns/group.rs
@@ -1,6 +1,4 @@
 use crate::process::ProcessInfo;
-#[cfg(target_os = "windows")]
-use crate::util::format_sid;
 #[cfg(not(target_os = "windows"))]
 use crate::util::USERS_CACHE;
 use crate::{column_default, Column};
@@ -87,20 +85,22 @@ impl Column for Group {
             return;
         };
 
-        let mut sid_name = primary;
+        let mut sid = primary;
         let mut kind = u64::MAX;
         for g in &proc.groups {
-            if g.sid.len() > 3 && g.sid[1] == 5 && g.sid[2] == 32 && kind > g.sid[3] {
-                sid_name = g;
-                kind = g.sid[3];
+            let subs = g.sub_authorities();
+            if g.authority() == 5
+                && subs.first() == Some(&32)
+                && u64::from(subs.get(1).copied().unwrap_or(u32::MAX)) < kind
+            {
+                sid = g;
+                kind = u64::from(subs[1]);
             }
         }
 
-        let fmt_content = if let Some(name) = &sid_name.name {
-            name.clone()
-        } else {
-            format_sid(&sid_name.sid, self.abbr_sid)
-        };
+        let fmt_content = sid
+            .display_name()
+            .unwrap_or_else(|| sid.format(self.abbr_sid));
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);

--- a/src/columns/group.rs
+++ b/src/columns/group.rs
@@ -1,4 +1,6 @@
 use crate::process::ProcessInfo;
+#[cfg(target_os = "windows")]
+use crate::process::SID_MAX;
 #[cfg(not(target_os = "windows"))]
 use crate::util::USERS_CACHE;
 use crate::{column_default, Column};
@@ -76,31 +78,16 @@ impl Column for Group {
 #[cfg(target_os = "windows")]
 impl Column for Group {
     fn add(&mut self, proc: &ProcessInfo) {
-        // A process whose token could not be opened - a protected process, or
-        // any process when procs is not elevated - has no group list. Render
-        // nothing rather than indexing a non-existent primary group.
-        let Some(primary) = proc.groups.first() else {
-            self.fmt_contents.insert(proc.pid, String::new());
-            self.raw_contents.insert(proc.pid, String::new());
-            return;
-        };
-
-        let mut sid = primary;
-        let mut kind = u64::MAX;
-        for g in &proc.groups {
-            let subs = g.sub_authorities();
-            if g.authority() == 5
-                && subs.first() == Some(&32)
-                && u64::from(subs.get(1).copied().unwrap_or(u32::MAX)) < kind
-            {
-                sid = g;
-                kind = u64::from(subs[1]);
-            }
-        }
-
-        let fmt_content = sid
-            .display_name()
-            .unwrap_or_else(|| sid.format(self.abbr_sid));
+        // The token is opened here rather than while collecting, so a run
+        // that does not show this column never pays for it.
+        let fmt_content = groups_of(proc.pid)
+            .as_deref()
+            .and_then(primary_group)
+            .map(|sid| {
+                sid.display_name()
+                    .unwrap_or_else(|| sid.format(self.abbr_sid))
+            })
+            .unwrap_or_default();
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);
@@ -108,6 +95,89 @@ impl Column for Group {
     }
 
     column_default!(String, false);
+}
+
+/// The token groups of `pid`, or `None` when its token cannot be opened - a
+/// protected process, or any process when procs is not elevated.
+///
+/// Reading the groups costs an `OpenProcess` and two token calls per process,
+/// so it is done here, lazily, instead of during collection: only a run that
+/// displays a group column pays for it, and only for the pids it displays.
+/// A thread row carries a thread id rather than a pid, so its lookup fails
+/// and it renders as empty - the same thing `Arch` and `WorkDir` do.
+#[cfg(target_os = "windows")]
+pub fn groups_of(pid: i32) -> Option<Vec<SID_MAX>> {
+    use std::mem::zeroed;
+    use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE};
+    use windows_sys::Win32::Security::{TOKEN_GROUPS, TOKEN_QUERY, TokenGroups};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, OpenProcessToken, PROCESS_QUERY_INFORMATION,
+    };
+
+    // 0 is the idle process, which owns no token; negative pids are not real.
+    if pid <= 0 {
+        return None;
+    }
+
+    // SAFETY: `pid` is only handed to `OpenProcess`, and the handle it hands
+    // back is closed before this function returns.
+    let handle: HANDLE = unsafe { OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pid as u32) };
+    if handle.is_null() {
+        return None;
+    }
+
+    let mut token: HANDLE = unsafe { zeroed() };
+    let ret = unsafe { OpenProcessToken(handle, TOKEN_QUERY, &mut token) };
+    if ret == 0 {
+        unsafe { CloseHandle(handle) };
+        return None;
+    }
+
+    // The SID pointers live inside this buffer, so it has to outlive them.
+    let buf = crate::process::token_information(token, TokenGroups);
+    unsafe {
+        CloseHandle(token);
+        CloseHandle(handle);
+    }
+    let buf = buf?;
+
+    let mut groups = Vec::new();
+    #[allow(clippy::cast_ptr_alignment)]
+    let token_groups = buf.as_ptr() as *const TOKEN_GROUPS;
+
+    // SAFETY: `token_information` returns only when `GetTokenInformation`
+    // succeeded, so `buf` holds a `TOKEN_GROUPS` followed by `GroupCount`
+    // `SID_AND_ATTRIBUTES`. Every SID is copied into an owned `SID_MAX`
+    // before `buf` is dropped, so no pointer outlives the buffer.
+    unsafe {
+        let sa = (*token_groups).Groups.as_ptr();
+        for i in 0..(*token_groups).GroupCount {
+            let psid = (*sa.offset(i as isize)).Sid;
+            groups.push(SID_MAX::from_psid(psid));
+        }
+    }
+
+    Some(groups)
+}
+
+/// The group a process is attributed to: the lowest-numbered well-known
+/// builtin group (`S-1-5-32-x`), or the primary group of the token when it
+/// carries no builtin group at all.
+#[cfg(target_os = "windows")]
+pub fn primary_group(groups: &[SID_MAX]) -> Option<&SID_MAX> {
+    let mut sid = groups.first()?;
+    let mut kind = u64::MAX;
+    for g in groups {
+        let subs = g.sub_authorities();
+        if g.authority() == 5
+            && subs.first() == Some(&32)
+            && u64::from(subs.get(1).copied().unwrap_or(u32::MAX)) < kind
+        {
+            sid = g;
+            kind = u64::from(subs[1]);
+        }
+    }
+    Some(sid)
 }
 
 #[cfg(target_os = "freebsd")]

--- a/src/columns/os_windows.rs
+++ b/src/columns/os_windows.rs
@@ -3,6 +3,7 @@ pub mod command;
 pub mod cpu_time;
 pub mod elapsed_time;
 pub mod empty;
+pub mod env;
 pub mod file_name;
 pub mod gid;
 pub mod group;
@@ -40,6 +41,7 @@ pub use self::command::Command;
 pub use self::cpu_time::CpuTime;
 pub use self::elapsed_time::ElapsedTime;
 pub use self::empty::Empty;
+pub use self::env::Env;
 pub use self::file_name::FileName;
 pub use self::gid::Gid;
 pub use self::group::Group;
@@ -89,6 +91,7 @@ pub enum ConfigColumnKind {
     CpuTime,
     ElapsedTime,
     Empty,
+    Env,
     FileName,
     Gid,
     Group,
@@ -141,6 +144,7 @@ pub fn gen_column(
         ConfigColumnKind::CpuTime => Box::new(CpuTime::new(header)),
         ConfigColumnKind::ElapsedTime => Box::new(ElapsedTime::new(header)),
         ConfigColumnKind::Empty => Box::new(Empty::new()),
+        ConfigColumnKind::Env => Box::new(Env::new(header, _procfs)),
         ConfigColumnKind::FileName => Box::new(FileName::new(header)),
         ConfigColumnKind::Gid => Box::new(Gid::new(header, abbr_sid)),
         ConfigColumnKind::Group => Box::new(Group::new(header, abbr_sid)),
@@ -199,6 +203,10 @@ pub static KIND_LIST: Lazy<BTreeMap<ConfigColumnKind, (&'static str, &'static st
                 ("ElapsedTime", "Elapsed time"),
             ),
             (ConfigColumnKind::Empty, ("Empty", "Empty")),
+            (
+                ConfigColumnKind::Env,
+                ("Env", "Environment variables"),
+            ),
             (
                 ConfigColumnKind::FileName,
                 ("FileName", "File name of the process image"),
@@ -455,6 +463,9 @@ kind = "ElapsedTime"
 style = "BrightYellow"
 [[columns]]
 kind = "Empty"
+style = "BrightYellow"
+[[columns]]
+kind = "Env"
 style = "BrightYellow"
 [[columns]]
 kind = "FileName"

--- a/src/columns/os_windows.rs
+++ b/src/columns/os_windows.rs
@@ -14,7 +14,9 @@ pub mod ppid;
 pub mod priority;
 pub mod rt_priority;
 pub mod read_bytes;
+pub mod recv_bytes;
 pub mod separator;
+pub mod send_bytes;
 pub mod session;
 pub mod slot;
 pub mod start_time;
@@ -52,7 +54,9 @@ pub use self::ppid::Ppid;
 pub use self::priority::Priority;
 pub use self::rt_priority::RtPriority;
 pub use self::read_bytes::ReadBytes;
+pub use self::recv_bytes::RecvBytes;
 pub use self::separator::Separator;
+pub use self::send_bytes::SendBytes;
 pub use self::session::Session;
 pub use self::slot::Slot;
 pub use self::start_time::StartTime;
@@ -101,7 +105,9 @@ pub enum ConfigColumnKind {
     Ppid,
     Priority,
     ReadBytes,
+    RecvBytes,
     RtPriority,
+    SendBytes,
     Separator,
     Session,
     Slot,
@@ -154,7 +160,9 @@ pub fn gen_column(
         ConfigColumnKind::Ppid => Box::new(Ppid::new(header)),
         ConfigColumnKind::Priority => Box::new(Priority::new(header)),
         ConfigColumnKind::ReadBytes => Box::new(ReadBytes::new(header)),
+        ConfigColumnKind::RecvBytes => Box::new(RecvBytes::new(header)),
         ConfigColumnKind::RtPriority => Box::new(RtPriority::new(header)),
+        ConfigColumnKind::SendBytes => Box::new(SendBytes::new(header)),
         ConfigColumnKind::Separator => Box::new(Separator::new(separator)),
         ConfigColumnKind::Session => Box::new(Session::new(header)),
         ConfigColumnKind::Slot => Box::new(Slot::new()),
@@ -229,8 +237,16 @@ pub static KIND_LIST: Lazy<BTreeMap<ConfigColumnKind, (&'static str, &'static st
                 ("ReadBytes", "Read bytes from storage"),
             ),
             (
+                ConfigColumnKind::RecvBytes,
+                ("RecvBytes", "Received bytes per second (Windows 11)"),
+            ),
+            (
                 ConfigColumnKind::RtPriority,
                 ("RtPriority", "Kernel base priority (0-31)"),
+            ),
+            (
+                ConfigColumnKind::SendBytes,
+                ("SendBytes", "Sent bytes per second (Windows 11)"),
             ),
             (
                 ConfigColumnKind::Separator,
@@ -402,6 +418,18 @@ nonnumeric_search = false
 align = "Right"
 [[columns]]
 kind = "WriteBytes"
+style = "ByUnit"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+[[columns]]
+kind = "RecvBytes"
+style = "ByUnit"
+numeric_search = false
+nonnumeric_search = false
+align = "Right"
+[[columns]]
+kind = "SendBytes"
 style = "ByUnit"
 numeric_search = false
 nonnumeric_search = false

--- a/src/columns/os_windows.rs
+++ b/src/columns/os_windows.rs
@@ -17,6 +17,7 @@ pub mod separator;
 pub mod session;
 pub mod slot;
 pub mod start_time;
+pub mod state;
 pub mod tcp_port;
 pub mod threads;
 pub mod tree;
@@ -52,6 +53,7 @@ pub use self::separator::Separator;
 pub use self::session::Session;
 pub use self::slot::Slot;
 pub use self::start_time::StartTime;
+pub use self::state::State;
 pub use self::tcp_port::TcpPort;
 pub use self::threads::Threads;
 pub use self::tree::Tree;
@@ -99,6 +101,7 @@ pub enum ConfigColumnKind {
     Session,
     Slot,
     StartTime,
+    State,
     TcpPort,
     Threads,
     Tree,
@@ -149,6 +152,7 @@ pub fn gen_column(
         ConfigColumnKind::Session => Box::new(Session::new(header)),
         ConfigColumnKind::Slot => Box::new(Slot::new()),
         ConfigColumnKind::StartTime => Box::new(StartTime::new(header)),
+        ConfigColumnKind::State => Box::new(State::new(header)),
         ConfigColumnKind::TcpPort => Box::new(TcpPort::new(header)),
         ConfigColumnKind::Threads => Box::new(Threads::new(header)),
         ConfigColumnKind::Tree => Box::new(Tree::new(tree_symbols)),
@@ -229,6 +233,7 @@ pub static KIND_LIST: Lazy<BTreeMap<ConfigColumnKind, (&'static str, &'static st
                 ("Slot", "Slot for `--insert` option"),
             ),
             (ConfigColumnKind::StartTime, ("StartTime", "Starting time")),
+            (ConfigColumnKind::State, ("State", "Process state")),
             (ConfigColumnKind::TcpPort, ("TcpPort", "Bound TCP ports")),
             (ConfigColumnKind::Threads, ("Threads", "Thread count")),
             (

--- a/src/columns/os_windows.rs
+++ b/src/columns/os_windows.rs
@@ -10,6 +10,7 @@ pub mod multi_slot;
 pub mod pid;
 pub mod ppid;
 pub mod priority;
+pub mod rt_priority;
 pub mod read_bytes;
 pub mod separator;
 pub mod slot;
@@ -42,6 +43,7 @@ pub use self::multi_slot::MultiSlot;
 pub use self::pid::Pid;
 pub use self::ppid::Ppid;
 pub use self::priority::Priority;
+pub use self::rt_priority::RtPriority;
 pub use self::read_bytes::ReadBytes;
 pub use self::separator::Separator;
 pub use self::slot::Slot;
@@ -87,6 +89,7 @@ pub enum ConfigColumnKind {
     Ppid,
     Priority,
     ReadBytes,
+    RtPriority,
     Separator,
     Slot,
     StartTime,
@@ -134,6 +137,7 @@ pub fn gen_column(
         ConfigColumnKind::Ppid => Box::new(Ppid::new(header)),
         ConfigColumnKind::Priority => Box::new(Priority::new(header)),
         ConfigColumnKind::ReadBytes => Box::new(ReadBytes::new(header)),
+        ConfigColumnKind::RtPriority => Box::new(RtPriority::new(header)),
         ConfigColumnKind::Separator => Box::new(Separator::new(separator)),
         ConfigColumnKind::Slot => Box::new(Slot::new()),
         ConfigColumnKind::StartTime => Box::new(StartTime::new(header)),
@@ -195,6 +199,10 @@ pub static KIND_LIST: Lazy<BTreeMap<ConfigColumnKind, (&'static str, &'static st
             (
                 ConfigColumnKind::ReadBytes,
                 ("ReadBytes", "Read bytes from storage"),
+            ),
+            (
+                ConfigColumnKind::RtPriority,
+                ("RtPriority", "Kernel base priority (0-31)"),
             ),
             (
                 ConfigColumnKind::Separator,
@@ -490,5 +498,8 @@ kind = "VmSwap"
 style = "ByUnit"
 [[columns]]
 kind = "WriteBytes"
+style = "White"
+[[columns]]
+kind = "RtPriority"
 style = "White"
 "#;

--- a/src/columns/os_windows.rs
+++ b/src/columns/os_windows.rs
@@ -3,6 +3,7 @@ pub mod command;
 pub mod cpu_time;
 pub mod elapsed_time;
 pub mod empty;
+pub mod file_name;
 pub mod gid;
 pub mod group;
 pub mod maj_flt;
@@ -13,6 +14,7 @@ pub mod priority;
 pub mod rt_priority;
 pub mod read_bytes;
 pub mod separator;
+pub mod session;
 pub mod slot;
 pub mod start_time;
 pub mod tcp_port;
@@ -36,6 +38,7 @@ pub use self::command::Command;
 pub use self::cpu_time::CpuTime;
 pub use self::elapsed_time::ElapsedTime;
 pub use self::empty::Empty;
+pub use self::file_name::FileName;
 pub use self::gid::Gid;
 pub use self::group::Group;
 pub use self::maj_flt::MajFlt;
@@ -46,6 +49,7 @@ pub use self::priority::Priority;
 pub use self::rt_priority::RtPriority;
 pub use self::read_bytes::ReadBytes;
 pub use self::separator::Separator;
+pub use self::session::Session;
 pub use self::slot::Slot;
 pub use self::start_time::StartTime;
 pub use self::tcp_port::TcpPort;
@@ -81,6 +85,7 @@ pub enum ConfigColumnKind {
     CpuTime,
     ElapsedTime,
     Empty,
+    FileName,
     Gid,
     Group,
     MajFlt,
@@ -91,6 +96,7 @@ pub enum ConfigColumnKind {
     ReadBytes,
     RtPriority,
     Separator,
+    Session,
     Slot,
     StartTime,
     TcpPort,
@@ -129,6 +135,7 @@ pub fn gen_column(
         ConfigColumnKind::CpuTime => Box::new(CpuTime::new(header)),
         ConfigColumnKind::ElapsedTime => Box::new(ElapsedTime::new(header)),
         ConfigColumnKind::Empty => Box::new(Empty::new()),
+        ConfigColumnKind::FileName => Box::new(FileName::new(header)),
         ConfigColumnKind::Gid => Box::new(Gid::new(header, abbr_sid)),
         ConfigColumnKind::Group => Box::new(Group::new(header, abbr_sid)),
         ConfigColumnKind::MajFlt => Box::new(MajFlt::new(header)),
@@ -139,6 +146,7 @@ pub fn gen_column(
         ConfigColumnKind::ReadBytes => Box::new(ReadBytes::new(header)),
         ConfigColumnKind::RtPriority => Box::new(RtPriority::new(header)),
         ConfigColumnKind::Separator => Box::new(Separator::new(separator)),
+        ConfigColumnKind::Session => Box::new(Session::new(header)),
         ConfigColumnKind::Slot => Box::new(Slot::new()),
         ConfigColumnKind::StartTime => Box::new(StartTime::new(header)),
         ConfigColumnKind::TcpPort => Box::new(TcpPort::new(header)),
@@ -183,6 +191,10 @@ pub static KIND_LIST: Lazy<BTreeMap<ConfigColumnKind, (&'static str, &'static st
                 ("ElapsedTime", "Elapsed time"),
             ),
             (ConfigColumnKind::Empty, ("Empty", "Empty")),
+            (
+                ConfigColumnKind::FileName,
+                ("FileName", "File name of the process image"),
+            ),
             (ConfigColumnKind::Gid, ("Gid", "Group ID")),
             (ConfigColumnKind::Group, ("Group", "Group name")),
             (
@@ -207,6 +219,10 @@ pub static KIND_LIST: Lazy<BTreeMap<ConfigColumnKind, (&'static str, &'static st
             (
                 ConfigColumnKind::Separator,
                 ("Separator", "Show | for column separation"),
+            ),
+            (
+                ConfigColumnKind::Session,
+                ("Session", "Session ID"),
             ),
             (
                 ConfigColumnKind::Slot,
@@ -428,6 +444,9 @@ style = "BrightYellow"
 kind = "Empty"
 style = "BrightYellow"
 [[columns]]
+kind = "FileName"
+style = "White"
+[[columns]]
 kind = "Gid"
 style = "White"
 [[columns]]
@@ -453,6 +472,9 @@ kind = "ReadBytes"
 style = "Cyan"
 [[columns]]
 kind = "Separator"
+style = "White"
+[[columns]]
+kind = "Session"
 style = "White"
 [[columns]]
 kind = "StartTime"

--- a/src/columns/os_windows.rs
+++ b/src/columns/os_windows.rs
@@ -32,6 +32,7 @@ pub mod vm_pin;
 pub mod vm_rss;
 pub mod vm_size;
 pub mod vm_swap;
+pub mod work_dir;
 pub mod write_bytes;
 
 pub use self::arch::Arch;
@@ -68,6 +69,7 @@ pub use self::vm_pin::VmPin;
 pub use self::vm_rss::VmRss;
 pub use self::vm_size::VmSize;
 pub use self::vm_swap::VmSwap;
+pub use self::work_dir::WorkDir;
 pub use self::write_bytes::WriteBytes;
 
 use crate::column::Column;
@@ -116,6 +118,7 @@ pub enum ConfigColumnKind {
     VmRss,
     VmSize,
     VmSwap,
+    WorkDir,
     WriteBytes,
 }
 
@@ -167,6 +170,7 @@ pub fn gen_column(
         ConfigColumnKind::VmRss => Box::new(VmRss::new(header)),
         ConfigColumnKind::VmSize => Box::new(VmSize::new(header)),
         ConfigColumnKind::VmSwap => Box::new(VmSwap::new(header)),
+        ConfigColumnKind::WorkDir => Box::new(WorkDir::new(header, _procfs)),
         ConfigColumnKind::WriteBytes => Box::new(WriteBytes::new(header)),
     }
 }
@@ -258,6 +262,10 @@ pub static KIND_LIST: Lazy<BTreeMap<ConfigColumnKind, (&'static str, &'static st
             (
                 ConfigColumnKind::VmSwap,
                 ("VmSwap", "Swapped-out virtual memory size"),
+            ),
+            (
+                ConfigColumnKind::WorkDir,
+                ("WorkDir", "Current working directory"),
             ),
             (
                 ConfigColumnKind::WriteBytes,

--- a/src/columns/os_windows.rs
+++ b/src/columns/os_windows.rs
@@ -1,3 +1,4 @@
+pub mod arch;
 pub mod command;
 pub mod cpu_time;
 pub mod elapsed_time;
@@ -29,6 +30,7 @@ pub mod vm_size;
 pub mod vm_swap;
 pub mod write_bytes;
 
+pub use self::arch::Arch;
 pub use self::command::Command;
 pub use self::cpu_time::CpuTime;
 pub use self::elapsed_time::ElapsedTime;
@@ -72,6 +74,7 @@ use std::path::PathBuf;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ConfigColumnKind {
+    Arch,
     Command,
     CpuTime,
     ElapsedTime,
@@ -118,6 +121,7 @@ pub fn gen_column(
     _procfs: Option<PathBuf>,
 ) -> Box<dyn Column> {
     match kind {
+        ConfigColumnKind::Arch => Box::new(Arch::new(header)),
         ConfigColumnKind::Command => Box::new(Command::new(header)),
         ConfigColumnKind::CpuTime => Box::new(CpuTime::new(header)),
         ConfigColumnKind::ElapsedTime => Box::new(ElapsedTime::new(header)),
@@ -158,6 +162,10 @@ pub fn gen_column(
 pub static KIND_LIST: Lazy<BTreeMap<ConfigColumnKind, (&'static str, &'static str)>> =
     Lazy::new(|| {
         [
+            (
+                ConfigColumnKind::Arch,
+                ("Arch", "Architecture of the process image"),
+            ),
             (
                 ConfigColumnKind::Command,
                 ("Command", "Command with all arguments"),

--- a/src/columns/priority.rs
+++ b/src/columns/priority.rs
@@ -54,16 +54,11 @@ impl Column for Priority {
 #[cfg(target_os = "windows")]
 impl Column for Priority {
     fn add(&mut self, proc: &ProcessInfo) {
-        let raw_content = i64::from(proc.priority);
-        let fmt_content = match raw_content {
-            0x0020 => String::from("Normal"),
-            0x0040 => String::from("Idle"),
-            0x0080 => String::from("High"),
-            0x0100 => String::from("Realtime"),
-            0x4000 => String::from("BelowNormal"),
-            0x8000 => String::from("AboveNormal"),
-            _ => String::from("Unknown"),
-        };
+        // This is the kernel Base Priority, which is not the same as the user-mode priority class.
+        // To get the user-mode priority class, we would need GetPriorityClass / NtQueryInformationProcess syscall
+        // on the process handle, but that would require additional permissions and is not always available.
+        let raw_content = proc.priority as i64;
+        let fmt_content = format!("{raw_content}");
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);

--- a/src/columns/priority.rs
+++ b/src/columns/priority.rs
@@ -62,8 +62,15 @@ impl Column for Priority {
         let (raw_content, fmt_content) = match priority_class_of(proc.pid) {
             Some(class) => (class as i64, priority_class_name(class).to_string()),
             // Protected processes (e.g. PPL) refuse the open, so fall back to
-            // the kernel priority, which is always available.
-            None => (proc.priority as i64, proc.priority.to_string()),
+            // the kernel Base Priority, which is always available. The class
+            // derived from it is only an approximation.
+            None => {
+                let class = priority_class_from_base(proc.priority);
+                (
+                    class as i64,
+                    format!("{} *", priority_class_name(class)),
+                )
+            },
         };
 
         self.fmt_contents.insert(proc.pid, fmt_content);
@@ -113,6 +120,29 @@ fn priority_class_name(class: u32) -> &'static str {
         HIGH_PRIORITY_CLASS => "High",
         REALTIME_PRIORITY_CLASS => "Realtime",
         _ => "Unknown",
+    }
+}
+
+/// Approximate a priority class from the kernel Base Priority when
+/// `OpenProcess` is unavailable (e.g. protected processes). The Base Priority
+/// is the class's base value plus any thread-level delta, so the mapping is
+/// only an approximation and the caller wraps the result in parentheses.
+#[cfg(target_os = "windows")]
+fn priority_class_from_base(base: i32) -> u32 {
+    use windows_sys::Win32::System::Threading::{
+        ABOVE_NORMAL_PRIORITY_CLASS, BELOW_NORMAL_PRIORITY_CLASS, HIGH_PRIORITY_CLASS,
+        IDLE_PRIORITY_CLASS, NORMAL_PRIORITY_CLASS, REALTIME_PRIORITY_CLASS,
+    };
+
+    // Base priorities: Idle=4, BelowNormal=6, Normal=8, AboveNormal=10,
+    // High=13, Realtime=24. Pick the class whose base value is closest.
+    match base {
+        b if b <= ((4 + 6) / 2) as i32 => IDLE_PRIORITY_CLASS,
+        b if b <= ((6 + 8) / 2) as i32 => BELOW_NORMAL_PRIORITY_CLASS,
+        b if b <= ((8 + 10) / 2) as i32 => NORMAL_PRIORITY_CLASS,
+        b if b <= ((10 + 13) / 2) as i32 => ABOVE_NORMAL_PRIORITY_CLASS,
+        b if b <= ((13 + 24) / 2) as i32 => HIGH_PRIORITY_CLASS,
+        _ => REALTIME_PRIORITY_CLASS,
     }
 }
 

--- a/src/columns/priority.rs
+++ b/src/columns/priority.rs
@@ -54,17 +54,66 @@ impl Column for Priority {
 #[cfg(target_os = "windows")]
 impl Column for Priority {
     fn add(&mut self, proc: &ProcessInfo) {
-        // This is the kernel Base Priority, which is not the same as the user-mode priority class.
-        // To get the user-mode priority class, we would need GetPriorityClass / NtQueryInformationProcess syscall
-        // on the process handle, but that would require additional permissions and is not always available.
-        let raw_content = proc.priority as i64;
-        let fmt_content = format!("{raw_content}");
+        // User-mode priority class - what the user configured via Task Manager,
+        // `STARTUPINFO`, or `SetPriorityClass`. It is queried only when this
+        // column is actually displayed: `add` runs once per process for the
+        // processes the column is shown for. The kernel Base Priority lives in
+        // `proc.priority` and is surfaced by the `RtPriority` column.
+        let (raw_content, fmt_content) = match priority_class_of(proc.pid) {
+            Some(class) => (class as i64, priority_class_name(class).to_string()),
+            // Protected processes (e.g. PPL) refuse the open, so fall back to
+            // the kernel priority, which is always available.
+            None => (proc.priority as i64, proc.priority.to_string()),
+        };
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);
     }
 
     column_default!(i64, true);
+}
+
+#[cfg(target_os = "windows")]
+fn priority_class_of(pid: i32) -> Option<u32> {
+    use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE};
+    use windows_sys::Win32::System::Threading::{
+        GetPriorityClass, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    if pid <= 0 {
+        return None;
+    }
+
+    // SAFETY: `pid` is only handed to `OpenProcess`, and the handle it returns
+    // is closed before this function returns.
+    let handle: HANDLE = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid as u32) };
+    if handle.is_null() {
+        return None;
+    }
+
+    let class = unsafe { GetPriorityClass(handle) };
+    unsafe { CloseHandle(handle) };
+
+    // A return of 0 means the call failed.
+    if class == 0 { None } else { Some(class) }
+}
+
+#[cfg(target_os = "windows")]
+fn priority_class_name(class: u32) -> &'static str {
+    use windows_sys::Win32::System::Threading::{
+        ABOVE_NORMAL_PRIORITY_CLASS, BELOW_NORMAL_PRIORITY_CLASS, HIGH_PRIORITY_CLASS,
+        IDLE_PRIORITY_CLASS, NORMAL_PRIORITY_CLASS, REALTIME_PRIORITY_CLASS,
+    };
+
+    match class {
+        IDLE_PRIORITY_CLASS => "Idle",
+        BELOW_NORMAL_PRIORITY_CLASS => "BelowNormal",
+        NORMAL_PRIORITY_CLASS => "Normal",
+        ABOVE_NORMAL_PRIORITY_CLASS => "AboveNormal",
+        HIGH_PRIORITY_CLASS => "High",
+        REALTIME_PRIORITY_CLASS => "Realtime",
+        _ => "Unknown",
+    }
 }
 
 #[cfg(target_os = "freebsd")]

--- a/src/columns/recv_bytes.rs
+++ b/src/columns/recv_bytes.rs
@@ -1,0 +1,55 @@
+use crate::process::ProcessInfo;
+use crate::util::bytify;
+use crate::{Column, column_default};
+use std::cmp;
+use std::collections::HashMap;
+
+/// Bytes received per second.
+///
+/// Windows only: the counters come from `ProcessNetworkIoInformation`
+/// (`PROCESS_NETWORK_COUNTERS::BytesIn`), so the column is declared by
+/// `os_windows.rs` alone. It reads a rate, which needs the two samples
+/// `collect_proc` takes; a process that could not be opened, or a Windows
+/// older than 11, reports zero.
+pub struct RecvBytes {
+    header: String,
+    unit: String,
+    fmt_contents: HashMap<i32, String>,
+    raw_contents: HashMap<i32, u64>,
+    width: usize,
+}
+
+impl RecvBytes {
+    pub fn new(header: Option<String>) -> Self {
+        let header = header.unwrap_or_else(|| String::from("Recv"));
+        let unit = String::from("[B/s]");
+        Self {
+            fmt_contents: HashMap::new(),
+            raw_contents: HashMap::new(),
+            width: 0,
+            header,
+            unit,
+        }
+    }
+}
+
+impl Column for RecvBytes {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let interval_ms =
+            (proc.interval.as_secs() * 1000 + u64::from(proc.interval.subsec_millis())).max(1);
+        let io = proc
+            .net_info
+            .curr_recv
+            .saturating_sub(proc.net_info.prev_recv)
+            * 1000
+            / interval_ms;
+
+        let raw_content = io;
+        let fmt_content = bytify(raw_content);
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(u64, true);
+}

--- a/src/columns/rt_priority.rs
+++ b/src/columns/rt_priority.rs
@@ -25,6 +25,7 @@ impl RtPriority {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 impl Column for RtPriority {
     fn add(&mut self, proc: &ProcessInfo) {
         let raw_content = proc.curr_proc.stat().rt_priority.unwrap_or_default();
@@ -33,6 +34,22 @@ impl Column for RtPriority {
         } else {
             String::new()
         };
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(u32, true);
+}
+
+#[cfg(target_os = "windows")]
+impl Column for RtPriority {
+    fn add(&mut self, proc: &ProcessInfo) {
+        // Windows has nothing like the POSIX real-time priority. This column
+        // shows the kernel Base Priority (0-31), the scheduling priority the
+        // kernel actually uses - the "real" priority of the process.
+        let raw_content = proc.priority as u32;
+        let fmt_content = format!("{}", raw_content);
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);

--- a/src/columns/send_bytes.rs
+++ b/src/columns/send_bytes.rs
@@ -1,0 +1,55 @@
+use crate::process::ProcessInfo;
+use crate::util::bytify;
+use crate::{Column, column_default};
+use std::cmp;
+use std::collections::HashMap;
+
+/// Bytes sent per second.
+///
+/// Windows only: the counters come from `ProcessNetworkIoInformation`
+/// (`PROCESS_NETWORK_COUNTERS::BytesOut`), so the column is declared by
+/// `os_windows.rs` alone. It reads a rate, which needs the two samples
+/// `collect_proc` takes; a process that could not be opened, or a Windows
+/// older than 11, reports zero.
+pub struct SendBytes {
+    header: String,
+    unit: String,
+    fmt_contents: HashMap<i32, String>,
+    raw_contents: HashMap<i32, u64>,
+    width: usize,
+}
+
+impl SendBytes {
+    pub fn new(header: Option<String>) -> Self {
+        let header = header.unwrap_or_else(|| String::from("Send"));
+        let unit = String::from("[B/s]");
+        Self {
+            fmt_contents: HashMap::new(),
+            raw_contents: HashMap::new(),
+            width: 0,
+            header,
+            unit,
+        }
+    }
+}
+
+impl Column for SendBytes {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let interval_ms =
+            (proc.interval.as_secs() * 1000 + u64::from(proc.interval.subsec_millis())).max(1);
+        let io = proc
+            .net_info
+            .curr_send
+            .saturating_sub(proc.net_info.prev_send)
+            * 1000
+            / interval_ms;
+
+        let raw_content = io;
+        let fmt_content = bytify(raw_content);
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(u64, true);
+}

--- a/src/columns/session.rs
+++ b/src/columns/session.rs
@@ -59,6 +59,19 @@ impl Column for Session {
     column_default!(i32, true);
 }
 
+#[cfg(target_os = "windows")]
+impl Column for Session {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let raw_content = proc.session;
+        let fmt_content = format!("{}", raw_content);
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(i32, true);
+}
+
 #[cfg(target_os = "freebsd")]
 impl Column for Session {
     fn add(&mut self, proc: &ProcessInfo) {

--- a/src/columns/state.rs
+++ b/src/columns/state.rs
@@ -3,6 +3,9 @@ use crate::{column_default, Column};
 use std::cmp;
 use std::collections::HashMap;
 
+#[cfg(target_os = "windows")]
+use crate::process::{thread_state, wait_reason, ThreadState};
+
 pub struct State {
     header: String,
     unit: String,
@@ -142,6 +145,67 @@ impl Column for State {
             state.push_str("J");
         }
         let fmt_content = state;
+        let raw_content = fmt_content.clone();
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(String, false);
+}
+
+// ---------------------------------------------------------------------------
+// Windows
+//
+// There is no per-process state to read: `SYSTEM_PROCESS_INFORMATION` only
+// counts the threads, while `SYSTEM_THREAD_INFORMATION` is what carries the
+// scheduler state. A row is therefore described by the threads behind it.
+// ---------------------------------------------------------------------------
+
+/// The letter `ps` prints for one thread's state.
+///
+/// `WaitReason` is only read while the thread is in `WAITING`: it is a leftover
+/// from the last wait otherwise, and a thread that is runnable again still
+/// carries the reason it sleeps on.
+#[cfg(target_os = "windows")]
+fn thread_state_char(state: ThreadState) -> char {
+    use thread_state::*;
+
+    match state.state {
+        // Runnable, or on its way there: `TRANSITION` only means the kernel
+        // stack is still being brought in.
+        INITIALIZED | READY | RUNNING | STANDBY | TRANSITION | DEFERRED_READY => 'R',
+        WAITING | GATE_WAIT | WAITING_FOR_PROCESS_IN_SWAP => match state.wait_reason {
+            wait_reason::SUSPENDED | wait_reason::WR_SUSPENDED => 'T',
+            _ => 'S',
+        },
+        TERMINATED => 'Z',
+        _ => '?',
+    }
+}
+
+/// The state letter of one row.
+///
+/// `state` is the most active thread's raw state, reduced by the snapshot
+/// layer; `thread_count` is the `NumberOfThreads` the snapshot reported. It
+/// is what separates a process that has no threads left from one whose
+/// records simply could not be read.
+#[cfg(target_os = "windows")]
+fn state_char(state: Option<ThreadState>, thread_count: i32) -> char {
+    match state {
+        // No thread left at all: the process has terminated and is only still
+        // listed because handles to it remain open.
+        None if thread_count <= 0 => 'Z',
+        // Threads were claimed but none could be read: not enough to call it.
+        None => '?',
+        Some(state) => thread_state_char(state),
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl Column for State {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let fmt_content = String::from(state_char(proc.state, proc.thread));
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);

--- a/src/columns/uid.rs
+++ b/src/columns/uid.rs
@@ -1,6 +1,4 @@
 use crate::process::ProcessInfo;
-#[cfg(target_os = "windows")]
-use crate::util::format_sid;
 use crate::{column_default, Column};
 use std::cmp;
 use std::collections::HashMap;
@@ -64,10 +62,11 @@ impl Column for Uid {
 #[cfg(target_os = "windows")]
 impl Column for Uid {
     fn add(&mut self, proc: &ProcessInfo) {
-        let (fmt_content, raw_content) = if let Some(user) = &proc.user {
+        let (fmt_content, raw_content) = if let Some(sid) = &proc.user {
+            let subs = sid.sub_authorities();
             (
-                format_sid(&user.sid, self.abbr_sid),
-                user.sid[user.sid.len() - 1] as u32,
+                sid.format(self.abbr_sid),
+                subs.last().copied().unwrap_or(0),
             )
         } else {
             (String::new(), 0)

--- a/src/columns/uid.rs
+++ b/src/columns/uid.rs
@@ -64,8 +64,14 @@ impl Column for Uid {
 #[cfg(target_os = "windows")]
 impl Column for Uid {
     fn add(&mut self, proc: &ProcessInfo) {
-        let fmt_content = format_sid(&proc.user.sid, self.abbr_sid);
-        let raw_content = proc.user.sid[proc.user.sid.len() - 1] as u32;
+        let (fmt_content, raw_content) = if let Some(user) = &proc.user {
+            (
+                format_sid(&user.sid, self.abbr_sid),
+                user.sid[user.sid.len() - 1] as u32,
+            )
+        } else {
+            (String::new(), 0)
+        };
 
         self.fmt_contents.insert(proc.pid, fmt_content);
         self.raw_contents.insert(proc.pid, raw_content);

--- a/src/columns/usage_mem.rs
+++ b/src/columns/usage_mem.rs
@@ -5,9 +5,7 @@ use procfs::{Current, Meminfo, WithCurrentSystemInfo};
 use std::cmp;
 use std::collections::HashMap;
 #[cfg(target_os = "windows")]
-use std::mem::{size_of, zeroed};
-#[cfg(target_os = "windows")]
-use windows_sys::Win32::System::ProcessStatus::{GetPerformanceInfo, PERFORMANCE_INFORMATION};
+use windows_sys::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
 
 pub struct UsageMem {
     header: String,
@@ -64,11 +62,12 @@ fn get_mem_total() -> u64 {
 
 #[cfg(target_os = "windows")]
 fn get_mem_total() -> u64 {
-    let mut info: PERFORMANCE_INFORMATION = unsafe { zeroed() };
-    let ret = unsafe { GetPerformanceInfo(&mut info, size_of::<PERFORMANCE_INFORMATION>() as u32) };
+    let mut info: MEMORYSTATUSEX = Default::default();
+    info.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+    let ret = unsafe { GlobalMemoryStatusEx(&mut info) };
 
     if ret != 0 {
-        info.PhysicalTotal as u64 * info.PageSize as u64
+        info.ullTotalPhys
     } else {
         0
     }

--- a/src/columns/usage_mem.rs
+++ b/src/columns/usage_mem.rs
@@ -62,8 +62,10 @@ fn get_mem_total() -> u64 {
 
 #[cfg(target_os = "windows")]
 fn get_mem_total() -> u64 {
-    let mut info: MEMORYSTATUSEX = Default::default();
-    info.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+    let mut info = MEMORYSTATUSEX {
+        dwLength: std::mem::size_of::<MEMORYSTATUSEX>() as u32,
+        ..Default::default()
+    };
     let ret = unsafe { GlobalMemoryStatusEx(&mut info) };
 
     if ret != 0 {

--- a/src/columns/user.rs
+++ b/src/columns/user.rs
@@ -1,6 +1,4 @@
 use crate::process::ProcessInfo;
-#[cfg(target_os = "windows")]
-use crate::util::format_sid;
 #[cfg(not(target_os = "windows"))]
 use crate::util::USERS_CACHE;
 use crate::{column_default, Column};
@@ -74,12 +72,9 @@ impl Column for User {
 #[cfg(target_os = "windows")]
 impl Column for User {
     fn add(&mut self, proc: &ProcessInfo) {
-        let fmt_content = if let Some(user) = &proc.user {
-            if let Some(name) = &user.name {
-                name.clone()
-            } else {
-                format_sid(&user.sid, self.abbr_sid)
-            }
+        let fmt_content = if let Some(sid) = &proc.user {
+            sid.display_name()
+                .unwrap_or_else(|| sid.format(self.abbr_sid))
         } else {
             String::new()
         };

--- a/src/columns/user.rs
+++ b/src/columns/user.rs
@@ -74,10 +74,14 @@ impl Column for User {
 #[cfg(target_os = "windows")]
 impl Column for User {
     fn add(&mut self, proc: &ProcessInfo) {
-        let fmt_content = if let Some(name) = &proc.user.name {
-            name.clone()
+        let fmt_content = if let Some(user) = &proc.user {
+            if let Some(name) = &user.name {
+                name.clone()
+            } else {
+                format_sid(&user.sid, self.abbr_sid)
+            }
         } else {
-            format_sid(&proc.user.sid, self.abbr_sid)
+            String::new()
         };
         let raw_content = fmt_content.clone();
 

--- a/src/columns/work_dir.rs
+++ b/src/columns/work_dir.rs
@@ -108,7 +108,8 @@ fn work_dir_of(pid: i32) -> Option<String> {
 fn read_work_dir(handle: HANDLE) -> Option<String> {
     use windows_sys::Win32::Foundation::UNICODE_STRING;
     use crate::process::{
-        process_peb_address, PEB_PREFIX, RTL_USER_PROCESS_PARAMETERS_PREFIX,
+        process_peb_address, read_process_memory, PEB_PREFIX,
+        RTL_USER_PROCESS_PARAMETERS_PREFIX,
     };
     use std::mem::{offset_of, size_of};
     use std::ptr;
@@ -177,30 +178,3 @@ fn read_work_dir(handle: HANDLE) -> Option<String> {
 /// allocation. Real working directories are capped well below this.
 #[cfg(target_os = "windows")]
 const MAX_WORK_DIR_BYTES: usize = 64 * 1024;
-
-/// Reads `buf.len()` bytes from the address space of `handle` at `addr`.
-///
-/// `addr` is an address in the target process; it must be readable with the
-/// handle's access rights. Returns `None` when the read fails or reads
-/// nothing.
-#[cfg(target_os = "windows")]
-fn read_process_memory<T>(handle: HANDLE, addr: usize, buf: &mut [T]) -> Option<()> {
-    use std::ffi::c_void;
-    use std::mem::size_of_val;
-    use windows_sys::Win32::System::Diagnostics::Debug::ReadProcessMemory;
-
-    let mut read: usize = 0;
-    let ok = unsafe {
-        ReadProcessMemory(
-            handle,
-            addr as *const c_void,
-            buf.as_mut_ptr().cast::<c_void>(),
-            size_of_val(buf),
-            &mut read,
-        )
-    };
-    if ok == 0 || read == 0 {
-        return None;
-    }
-    Some(())
-}

--- a/src/columns/work_dir.rs
+++ b/src/columns/work_dir.rs
@@ -4,12 +4,16 @@ use std::cmp;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::Foundation::HANDLE;
+
 pub struct WorkDir {
     header: String,
     unit: String,
     fmt_contents: HashMap<i32, String>,
     raw_contents: HashMap<i32, String>,
     width: usize,
+    #[allow(dead_code)]
     procfs: Option<PathBuf>,
 }
 
@@ -47,4 +51,155 @@ impl Column for WorkDir {
     }
 
     column_default!(String, false);
+}
+
+#[cfg(target_os = "windows")]
+impl Column for WorkDir {
+    fn add(&mut self, proc: &ProcessInfo) {
+        let fmt_content = work_dir_of(proc.pid).unwrap_or_default();
+        let raw_content = fmt_content.clone();
+
+        self.fmt_contents.insert(proc.pid, fmt_content);
+        self.raw_contents.insert(proc.pid, raw_content);
+    }
+
+    column_default!(String, false);
+}
+
+/// Reads the current working directory of `pid` from its PEB.
+///
+/// The PEB address comes from `NtQueryInformationProcess` with
+/// `ProcessBasicInformation`; the PEB and the process parameters it points at
+/// are then read with `ReadProcessMemory`. Needs
+/// `PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ`, so protected
+/// processes (e.g. PPL) yield `None`.
+#[cfg(target_os = "windows")]
+fn work_dir_of(pid: i32) -> Option<String> {
+    use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_VM_READ,
+    };
+
+    // 0 is the idle process and has no PEB; negative pids are not real.
+    if pid <= 0 {
+        return None;
+    }
+
+    // SAFETY: `pid` is only handed to `OpenProcess`, and the handle it returns
+    // is closed before this function returns.
+    let handle: HANDLE = unsafe {
+        OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ,
+            FALSE,
+            pid as u32,
+        )
+    };
+    if handle.is_null() {
+        return None;
+    }
+
+    let dir = read_work_dir(handle);
+    unsafe { CloseHandle(handle) };
+    dir
+}
+
+/// Reads the working directory out of the PEB of `handle`.
+#[cfg(target_os = "windows")]
+fn read_work_dir(handle: HANDLE) -> Option<String> {
+    use crate::process::{
+        process_peb_address, PEB_PREFIX, RTL_USER_PROCESS_PARAMETERS_PREFIX, UNICODE_STRING,
+    };
+    use std::mem::{offset_of, size_of};
+    use std::ptr;
+
+    // The PEB address lives in the target's address space.
+    let peb = process_peb_address(handle)?;
+
+    // Read the leading PEB fields. `ProcessParameters` sits within the first
+    // page, so a single read covers it.
+    let mut peb_buf = [0u64; 0x100 / size_of::<u64>()];
+    read_process_memory(handle, peb, &mut peb_buf)?;
+
+    // SAFETY: `peb_buf` is 8-byte aligned and `ProcessParameters` is a
+    // pointer-sized field at a pointer-aligned offset, so the read is aligned.
+    let params_addr = unsafe {
+        peb_buf
+            .as_ptr()
+            .cast::<u8>()
+            .add(offset_of!(PEB_PREFIX, ProcessParameters))
+            .cast::<usize>()
+            .read()
+    };
+    // A 32-bit address from a 64-bit reader means a WOW64 process, whose
+    // process parameters use the 32-bit layout; refuse rather than misparse.
+    if params_addr == 0 || (size_of::<usize>() == 8 && params_addr >> 32 == 0) {
+        return None;
+    }
+
+    // Read the leading process-parameters fields; `CurrentDirectory` sits
+    // within the first page.
+    let mut params_buf = [0u64; 0x100 / size_of::<u64>()];
+    read_process_memory(handle, params_addr, &mut params_buf)?;
+
+    // SAFETY: `params_buf` is 8-byte aligned and `CurrentDirectory` is at an
+    // 8-byte-aligned offset, so the `UNICODE_STRING` read is aligned.
+    let dos_path: UNICODE_STRING = unsafe {
+        ptr::read(
+            params_buf
+                .as_ptr()
+                .cast::<u8>()
+                .add(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, CurrentDirectory))
+                .cast::<UNICODE_STRING>(),
+        )
+    };
+    if dos_path.Buffer.is_null() || dos_path.Length == 0 {
+        return None;
+    }
+
+    let bytes = dos_path.Length as usize;
+    if bytes > MAX_WORK_DIR_BYTES {
+        return None;
+    }
+
+    // The string lives in the target's address space, so it needs its own read.
+    let mut chars = vec![0u16; bytes / 2];
+    read_process_memory(handle, dos_path.Buffer as usize, &mut chars)?;
+
+    Some(
+        String::from_utf16_lossy(&chars)
+            .trim_end_matches('\0')
+            .to_owned(),
+    )
+}
+
+/// Guard against a nonsensical `UNICODE_STRING::Length` turning into a huge
+/// allocation. Real working directories are capped well below this.
+#[cfg(target_os = "windows")]
+const MAX_WORK_DIR_BYTES: usize = 64 * 1024;
+
+/// Reads `buf.len()` bytes from the address space of `handle` at `addr`.
+///
+/// `addr` is an address in the target process; it must be readable with the
+/// handle's access rights. Returns `None` when the read fails or reads
+/// nothing.
+#[cfg(target_os = "windows")]
+fn read_process_memory<T>(handle: HANDLE, addr: usize, buf: &mut [T]) -> Option<()> {
+    use std::ffi::c_void;
+    use std::mem::size_of_val;
+    use windows_sys::Win32::System::Diagnostics::Debug::ReadProcessMemory;
+
+    let mut read: usize = 0;
+    let ok = unsafe {
+        ReadProcessMemory(
+            handle,
+            addr as *const c_void,
+            buf.as_mut_ptr().cast::<c_void>(),
+            size_of_val(buf),
+            &mut read,
+        )
+    };
+    if ok == 0 || read == 0 {
+        return None;
+    }
+    Some(())
 }

--- a/src/columns/work_dir.rs
+++ b/src/columns/work_dir.rs
@@ -106,8 +106,9 @@ fn work_dir_of(pid: i32) -> Option<String> {
 /// Reads the working directory out of the PEB of `handle`.
 #[cfg(target_os = "windows")]
 fn read_work_dir(handle: HANDLE) -> Option<String> {
+    use windows_sys::Win32::Foundation::UNICODE_STRING;
     use crate::process::{
-        process_peb_address, PEB_PREFIX, RTL_USER_PROCESS_PARAMETERS_PREFIX, UNICODE_STRING,
+        process_peb_address, PEB_PREFIX, RTL_USER_PROCESS_PARAMETERS_PREFIX,
     };
     use std::mem::{offset_of, size_of};
     use std::ptr;

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,6 +5,8 @@ pub mod linux;
 #[cfg(target_os = "macos")]
 pub mod macos;
 #[cfg(target_os = "windows")]
+mod ntapi;
+#[cfg(target_os = "windows")]
 pub mod windows;
 
 #[cfg(target_os = "freebsd")]

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -1,0 +1,420 @@
+//! Minimal NT API surface that `windows-sys` does not export.
+//!
+//! Every structure below is transcribed field-for-field from
+//! `winternl.h` (msys2 clang64); the source line is noted above each one.
+//! Field names are kept verbatim so the definitions stay diffable against
+//! the header, hence the `non_snake_case` allowances.
+
+use std::ffi::c_void;
+use std::mem::{align_of, size_of};
+use std::ptr;
+use std::sync::OnceLock;
+
+use windows_sys::Win32::Foundation::{HANDLE, HMODULE};
+use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
+use windows_sys::Win32::System::Threading::IO_COUNTERS;
+
+// ---------------------------------------------------------------------------
+// Structures
+// ---------------------------------------------------------------------------
+
+#[repr(C)]
+#[allow(non_snake_case)]
+#[derive(Copy, Clone)]
+pub struct UNICODE_STRING {
+    /// Byte length of `Buffer`, excluding any terminating NUL.
+    pub Length: u16,
+    pub MaximumLength: u16,
+    pub Buffer: *mut u16,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct VM_COUNTERS {
+    pub PeakVirtualSize: usize,
+    pub VirtualSize: usize,
+    pub PageFaultCount: u32,
+    pub PeakWorkingSetSize: usize,
+    pub WorkingSetSize: usize,
+    pub QuotaPeakPagedPoolUsage: usize,
+    pub QuotaPagedPoolUsage: usize,
+    pub QuotaPeakNonPagedPoolUsage: usize,
+    pub QuotaNonPagedPoolUsage: usize,
+    pub PagefileUsage: usize,
+    pub PeakPagefileUsage: usize,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct CLIENT_ID {
+    pub UniqueProcess: HANDLE,
+    pub UniqueThread: HANDLE,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct SYSTEM_THREADS {
+    pub KernelTime: i64,
+    pub UserTime: i64,
+    pub CreateTime: i64,
+    pub WaitTime: u32,
+    pub StartAddress: *mut c_void,
+    pub ClientId: CLIENT_ID,
+    pub Priority: i32,
+    pub BasePriority: i32,
+    pub ContextSwitchCount: u32,
+    pub State: u32,
+    pub WaitReason: u32,
+}
+
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct SYSTEM_PROCESS_INFORMATION {
+    pub NextEntryOffset: u32,
+    pub NumberOfThreads: u32,
+    pub WorkingSetPrivateSize: u64,
+    pub HardFaultCount: u32,
+    pub NumberOfThreadsHighWatermark: u32,
+    pub CycleTime: u64,
+    pub CreateTime: i64,
+    pub UserTime: i64,
+    pub KernelTime: i64,
+    pub ImageName: UNICODE_STRING,
+    pub BasePriority: i32,
+    pub UniqueProcessId: HANDLE,
+    pub InheritedFromUniqueProcessId: HANDLE,
+    pub HandleCount: u32,
+    pub SessionId: u32,
+    pub PageDirectoryBase: u32,
+    pub VirtualMemoryCounters: VM_COUNTERS,
+    pub PrivatePageCount: usize,
+    pub IoCounters: IO_COUNTERS,
+    /// C99-style flexible array member. The count is `NumberOfThreads`
+    pub Threads: [SYSTEM_THREADS; 0],
+    // String buffer for `ImageName`
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(size_of::<SYSTEM_PROCESS_INFORMATION>() == 256);
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(size_of::<SYSTEM_THREADS>() == 80);
+
+impl SYSTEM_PROCESS_INFORMATION {
+    /// Borrows the `Threads[]` flexible array trailing this process header.
+    ///
+    /// `NumberOfThreads` is the count the kernel stored, and for every entry
+    /// except the last the following `SYSTEM_PROCESS_INFORMATION` (at
+    /// `NextEntryOffset`) bounds the array, so the slice can never overreach
+    /// the next entry. The last entry has `NextEntryOffset == 0`; there the
+    /// buffer is sized by the kernel for exactly `NumberOfThreads` entries.
+    pub fn threads(&self) -> ThreadSlice<'_> {
+        let aligned = (self.Threads.as_ptr() as usize) % align_of::<SYSTEM_THREADS>() == 0;
+        let len = if aligned {
+            self.NumberOfThreads as usize
+        } else {
+            0
+        };
+        // SAFETY: `Threads` is the C99 flexible array member. `self` lives in
+        // a live snapshot buffer and `len` is the count the kernel reported, so
+        // the `len` `SYSTEM_THREADS` following the header are valid and the
+        // pointer is aligned (verified above).
+        let threads = unsafe { std::slice::from_raw_parts(self.Threads.as_ptr(), len) };
+        ThreadSlice {
+            threads,
+            pid: self.UniqueProcessId as usize,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// SystemInformationClass
+pub const SYSTEM_PROCESS_INFORMATION_CLASS: u32 = 5;
+/// ProcessInformationClass
+pub const PROCESS_COMMAND_LINE_INFORMATION_CLASS: u32 = 60;
+/// NTSTATUS
+pub const STATUS_SUCCESS: i32 = 0;
+pub const STATUS_INFO_LENGTH_MISMATCH: i32 = 0xC000_0004u32 as i32;
+
+/// Guard against a nonsensical `UNICODE_STRING::Length` turning into a huge
+/// allocation. Real command lines are capped well below this.
+const MAX_COMMAND_LINE_BYTES: usize = 64 * 1024;
+
+// ---------------------------------------------------------------------------
+// Function resolution
+// ---------------------------------------------------------------------------
+
+#[allow(non_snake_case)]
+type NtQuerySystemInformationFn = unsafe extern "system" fn(
+    SystemInformationClass: u32,
+    SystemInformation: *mut c_void,
+    SystemInformationLength: u32,
+    ReturnLength: *mut u32,
+) -> i32;
+
+#[allow(non_snake_case)]
+type NtQueryInformationProcessFn = unsafe extern "system" fn(
+    ProcessHandle: HANDLE,
+    ProcessInformationClass: u32,
+    ProcessInformation: *mut c_void,
+    ProcessInformationLength: u32,
+    ReturnLength: *mut u32,
+) -> i32;
+
+static NT_QUERY_SYSTEM_INFORMATION: OnceLock<Option<NtQuerySystemInformationFn>> = OnceLock::new();
+static NT_QUERY_INFORMATION_PROCESS: OnceLock<Option<NtQueryInformationProcessFn>> =
+    OnceLock::new();
+
+/// `ntdll.dll` is mapped into every user process, so a handle lookup is enough
+/// and there is nothing to release. Stored as `usize` because a bare
+/// `HMODULE` (a raw pointer) is not `Sync` and cannot live in a `static`.
+fn ntdll() -> HMODULE {
+    static HANDLE: OnceLock<usize> = OnceLock::new();
+    let addr = *HANDLE.get_or_init(|| {
+        let name: Vec<u16> = "ntdll.dll\0".encode_utf16().collect();
+        unsafe { GetModuleHandleW(name.as_ptr()) as usize }
+    });
+    addr as HMODULE
+}
+
+fn ntdll_proc(name: &[u8]) -> Option<unsafe extern "system" fn() -> isize> {
+    let module = ntdll();
+    if module.is_null() {
+        return None;
+    }
+    // SAFETY: `name` is NUL terminated and outlives the call.
+    unsafe { GetProcAddress(module, name.as_ptr()) }
+}
+
+pub fn nt_query_system_information() -> Option<NtQuerySystemInformationFn> {
+    *NT_QUERY_SYSTEM_INFORMATION.get_or_init(|| {
+        ntdll_proc(b"NtQuerySystemInformation\0")
+            // SAFETY: both are `extern "system"` fn pointers; the ABI matches.
+            .map(|f| unsafe { std::mem::transmute::<_, NtQuerySystemInformationFn>(f) })
+    })
+}
+
+pub fn nt_query_information_process() -> Option<NtQueryInformationProcessFn> {
+    *NT_QUERY_INFORMATION_PROCESS.get_or_init(|| {
+        ntdll_proc(b"NtQueryInformationProcess\0")
+            // SAFETY: both are `extern "system"` fn pointers; the ABI matches.
+            .map(|f| unsafe { std::mem::transmute::<_, NtQueryInformationProcessFn>(f) })
+    })
+}
+
+// ---------------------------------------------------------------------------
+// SystemProcessInformation
+// ---------------------------------------------------------------------------
+
+const INITIAL_BUF: usize = 64 * 1024;
+
+/// Takes one `SystemProcessInformation` snapshot.
+///
+/// The buffer is a `Vec<u64>` rather than a `Vec<u8>` because the structures
+/// require 8-byte alignment and a byte vector only guarantees 1.
+pub fn query_system_processes() -> Option<Vec<u64>> {
+    let query = nt_query_system_information()?;
+    let mut words = vec![0u64; INITIAL_BUF / size_of::<u64>()];
+
+    for _ in 0..8 {
+        let mut ret_len: u32 = 0;
+        let len = words.len() * size_of::<u64>();
+        let status = unsafe {
+            query(
+                SYSTEM_PROCESS_INFORMATION_CLASS,
+                words.as_mut_ptr().cast::<c_void>(),
+                len as u32,
+                ptr::addr_of_mut!(ret_len),
+            )
+        };
+
+        if status == STATUS_INFO_LENGTH_MISMATCH {
+            // `ret_len` is allowed to come back as 0, so double on our own too.
+            let want = (ret_len as usize).max(len * 2) + 4096;
+            words.resize(want.div_ceil(size_of::<u64>()), 0);
+            continue;
+        }
+        if status < 0 {
+            return None;
+        }
+        debug_assert_eq!(status, STATUS_SUCCESS);
+        return Some(words);
+    }
+
+    None
+}
+
+/// Decoded `SYSTEM_THREADS`, with the raw handles already narrowed to ids.
+pub struct ThreadInfo {
+    pub tid: i32,
+    pub create_time: i64,
+    pub kernel_time: u64,
+    pub user_time: u64,
+    pub priority: i32,
+}
+
+/// The `SYSTEM_THREADS` array trailing a `SYSTEM_PROCESS_INFORMATION`.
+pub struct ThreadSlice<'a> {
+    threads: &'a [SYSTEM_THREADS],
+    /// Owning process id, used to confirm the layout is what we expect.
+    pid: usize,
+}
+
+impl ThreadSlice<'_> {
+    pub fn len(&self) -> usize {
+        self.threads.len()
+    }
+
+    pub fn get(&self, index: usize) -> Option<ThreadInfo> {
+        let thread = self.threads.get(index)?;
+
+        // Every thread carries its owning process id. If a future Windows
+        // release moves the fields around this will not match, and the entry is
+        // dropped instead of being read as garbage.
+        if thread.ClientId.UniqueProcess as usize != self.pid {
+            return None;
+        }
+
+        Some(ThreadInfo {
+            tid: thread.ClientId.UniqueThread as usize as i32,
+            create_time: thread.CreateTime,
+            kernel_time: thread.KernelTime as u64,
+            user_time: thread.UserTime as u64,
+            priority: thread.Priority,
+        })
+    }
+}
+
+/// Walks the `SYSTEM_PROCESS_INFORMATION` entries of a buffer returned by
+/// [`query_system_processes`].
+pub struct ProcessIter<'a> {
+    buf: &'a [u64],
+    offset: usize,
+}
+
+impl<'a> ProcessIter<'a> {
+    pub fn new(buf: &'a [u64]) -> Self {
+        Self { buf, offset: 0 }
+    }
+
+    fn byte_len(&self) -> usize {
+        std::mem::size_of_val(self.buf)
+    }
+}
+
+impl<'a> Iterator for ProcessIter<'a> {
+    type Item = &'a SYSTEM_PROCESS_INFORMATION;
+
+    fn next(&mut self) -> Option<&'a SYSTEM_PROCESS_INFORMATION> {
+        let limit = self.byte_len();
+        let offset = self.offset;
+        let header = size_of::<SYSTEM_PROCESS_INFORMATION>();
+        if offset + header > limit {
+            return None;
+        }
+
+        let base = self.buf.as_ptr() as *const u8;
+        // SAFETY: the buffer is 8-byte aligned and `offset` only ever advances
+        // by `NextEntryOffset`, which keeps each entry aligned.
+        let info: &'a SYSTEM_PROCESS_INFORMATION =
+            unsafe { &*base.add(offset).cast::<SYSTEM_PROCESS_INFORMATION>() };
+
+        // `NextEntryOffset == 0` marks the last entry. Anything that would
+        // rewind, or leave the next entry misaligned, is malformed - stop
+        // rather than loop forever or dereference a bad pointer.
+        self.offset = match info.NextEntryOffset as usize {
+            0 => limit,
+            next if next < header || next % align_of::<SYSTEM_PROCESS_INFORMATION>() != 0 => limit,
+            next => offset.saturating_add(next),
+        };
+
+        Some(info)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ProcessCommandLineInformation
+// ---------------------------------------------------------------------------
+
+/// Reads the full command line of `handle`.
+///
+/// `ProcessCommandLineInformation` returns the `UNICODE_STRING` describing
+/// `PEB->ProcessParameters->CommandLine`. The returned `UNICODE_STRING::Buffer`
+/// is expected to point into the output buffer, where the kernel has copied
+/// the command-line characters.
+///
+/// Needs `PROCESS_QUERY_LIMITED_INFORMATION` and Windows 8.1 or newer.
+/// Anything else yields `None`.
+pub fn process_command_line(handle: HANDLE) -> Option<String> {
+    let query = nt_query_information_process()?;
+
+    // Room for the header plus a typical command line.
+    let mut buf = vec![0u64; (size_of::<UNICODE_STRING>() + 1024).div_ceil(size_of::<u64>())];
+    let mut status = STATUS_INFO_LENGTH_MISMATCH;
+
+    for _ in 0..4 {
+        let mut ret_len: u32 = 0;
+        status = unsafe {
+            query(
+                handle,
+                PROCESS_COMMAND_LINE_INFORMATION_CLASS,
+                buf.as_mut_ptr().cast::<c_void>(),
+                (buf.len() * size_of::<u64>()) as u32,
+                ptr::addr_of_mut!(ret_len),
+            )
+        };
+        if status != STATUS_INFO_LENGTH_MISMATCH {
+            break;
+        }
+        let want = (ret_len as usize).max(buf.len() * size_of::<u64>() * 2);
+        if want > MAX_COMMAND_LINE_BYTES {
+            return None;
+        }
+        buf.resize(want.div_ceil(size_of::<u64>()), 0);
+    }
+    if status < 0 {
+        return None;
+    }
+
+    // SAFETY: the buffer is 8-byte aligned and the query reported success.
+    let info: &UNICODE_STRING = unsafe { &*buf.as_ptr().cast::<UNICODE_STRING>() };
+    if info.Buffer.is_null() || info.Length == 0 {
+        return None;
+    }
+    let bytes = info.Length as usize;
+    if bytes > MAX_COMMAND_LINE_BYTES {
+        return None;
+    }
+
+    let start = buf.as_ptr() as usize;
+    let end = start + buf.len() * size_of::<u64>();
+    let addr = info.Buffer as usize;
+    let last = addr.checked_add(bytes)?;
+    if addr < start || last > end {
+        return None;
+    }
+
+    // SAFETY: the range was just verified to lie inside `buf`, which is still alive.
+    let chars = unsafe { std::slice::from_raw_parts(info.Buffer, bytes / 2) };
+
+    Some(
+        String::from_utf16_lossy(chars)
+            .trim_end_matches('\0')
+            .to_owned(),
+    )
+}
+
+/// Copies the characters of `string` out of `buffer`, which must still be
+/// alive (the `Buffer` pointer of an `ImageName` points inside it).
+pub fn unicode_string_to_owned(string: &UNICODE_STRING) -> String {
+    if string.Buffer.is_null() || string.Length == 0 {
+        return String::new();
+    }
+    let len = (string.Length / 2) as usize;
+    // SAFETY: `Buffer` points into the snapshot buffer, whose lifetime covers
+    // the `'a` of the `ProcessEntry` this came from.
+    let slice = unsafe { std::slice::from_raw_parts(string.Buffer, len) };
+    String::from_utf16_lossy(slice)
+}

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -6,12 +6,15 @@
 //! the header, hence the `non_snake_case` allowances.
 
 use std::ffi::c_void;
+use std::fmt::Write;
 use std::marker::PhantomData;
 use std::mem::{offset_of, size_of};
 use std::ptr;
+use std::slice;
 use std::sync::OnceLock;
 
 use windows_sys::Win32::Foundation::{HANDLE, HMODULE};
+use windows_sys::Win32::Security::{PSID, SECURITY_MAX_SID_SIZE, SID};
 use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
 use windows_sys::Win32::System::Threading::IO_COUNTERS;
 
@@ -176,6 +179,151 @@ const SID_HEADER_BYTES: usize = 8;
 const SID_REVISION: u8 = 1;
 /// `SID_MAX_SUB_AUTHORITIES`
 const SID_MAX_SUB_AUTHORITIES: usize = 15;
+
+/// An owned, fixed-size `SID` that can be stored by value.
+///
+/// `windows-sys`'s `SID` types its trailing sub-authorities as `[u32; 1]`, so
+/// it cannot hold a full SID by value. `SID_MAX` embeds the official `SID` as
+/// its first field and pads it out to `SECURITY_MAX_SID_SIZE` (68 bytes, the
+/// largest a SID can be: 8-byte header + 15 sub-authorities). The `#[repr(C)]`
+/// layout and the embedded `SID` give it the same alignment (4) as `SID`, so
+/// the first `8 + SubAuthorityCount * 4` bytes are a valid `PSID`.
+///
+/// Equality and hashing compare only the live SID bytes, never the padding.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SID_MAX {
+    /// The official `SID` header and first sub-authority.
+    pub sid: SID,
+    /// Padding to `SECURITY_MAX_SID_SIZE`; never read or compared.
+    _pad: [u8; SECURITY_MAX_SID_SIZE as usize - size_of::<SID>()],
+}
+
+impl SID_MAX {
+    /// The live bytes of this SID (header + `SubAuthorityCount` sub-authorities),
+    /// as a slice that is a valid `PSID` when cast to a pointer.
+    ///
+    /// The count is clamped to `SID_MAX_SUB_AUTHORITIES` so a corrupted
+    /// `SubAuthorityCount` cannot make the slice outrun the fixed buffer.
+    pub fn as_bytes(&self) -> &[u8] {
+        let count = (self.sid.SubAuthorityCount as usize).min(SID_MAX_SUB_AUTHORITIES);
+        let len = SID_HEADER_BYTES + count * size_of::<u32>();
+        // SAFETY: `self` is exactly `SECURITY_MAX_SID_SIZE` bytes, and `len` is
+        // clamped to at most 68, so the slice stays strictly in bounds.
+        unsafe { slice::from_raw_parts(self as *const Self as *const u8, len) }
+    }
+
+    /// Copies the SID pointed to by `psid` into a new `SID_MAX`, zeroing the
+    /// padding. `psid` must point at a valid SID.
+    ///
+    /// # Safety
+    /// `psid` must be a valid `PSID` whose `SubAuthorityCount` is at most 15.
+    pub unsafe fn from_psid(psid: PSID) -> SID_MAX {
+        let count = unsafe { (psid.cast::<u8>()).add(1).read() } as usize;
+
+        // Guard against a malformed PSID overflowing the fixed buffer.
+        assert!(
+            count <= SID_MAX_SUB_AUTHORITIES,
+            "PSID has {} sub-authorities, exceeding the maximum {}",
+            count,
+            SID_MAX_SUB_AUTHORITIES
+        );
+
+        let len = SID_HEADER_BYTES + count * size_of::<u32>();
+
+        // Zero-initialise the whole struct (header + padding).
+        let mut ret: SID_MAX = unsafe { std::mem::zeroed() };
+
+        // Copy the whole live SID by bytes, like `memcpy`, so the header and
+        // all sub-authorities land in `ret` even though `SID` only declares one.
+        unsafe {
+            ptr::copy_nonoverlapping(
+                psid.cast::<u8>(),
+                (&mut ret.sid as *mut SID).cast::<u8>(),
+                len,
+            );
+        }
+        ret
+    }
+
+    /// The sub-authorities of this SID, as a zero-allocation slice.
+    pub fn sub_authorities(&self) -> &[u32] {
+        let count = (self.sid.SubAuthorityCount as usize).min(SID_MAX_SUB_AUTHORITIES);
+        if count == 0 {
+            return &[];
+        }
+
+        // SAFETY: `SID_MAX` is `#[repr(C)]` and embeds a `[u32; 1]`, so it is
+        // at least 4-aligned. `SubAuthority` sits at offset 8, a multiple of 4,
+        // so the pointer is properly aligned for `u32`. The sub-authorities are
+        // contiguous, immediately following `SubAuthority[0]` in the buffer.
+        let sub_ptr = ptr::addr_of!(self.sid.SubAuthority) as *const u32;
+        unsafe { slice::from_raw_parts(sub_ptr, count) }
+    }
+
+    /// The 6-byte IdentifierAuthority of this SID, as a `u64`.
+    pub fn authority(&self) -> u64 {
+        let v = self.sid.IdentifierAuthority.Value;
+        u64::from_be_bytes([0, 0, v[0], v[1], v[2], v[3], v[4], v[5]])
+    }
+
+    /// Formats this SID as a string, abbreviating the middle sub-authorities
+    /// when `abbr` is set (e.g. `S-1-5-...-18` instead of the full form).
+    pub fn format(&self, abbr: bool) -> String {
+        let revision = self.sid.Revision;
+        let authority = self.authority();
+        let subs = self.sub_authorities();
+        let count = subs.len();
+
+        let mut ret = format!("S-{}-{}", revision, authority);
+        if count == 0 {
+            return ret;
+        }
+
+        // Append with `std::fmt::Write` to avoid O(N^2) string rebuilds.
+        write!(&mut ret, "-{}", subs[0]).unwrap();
+
+        if count > 1 {
+            if abbr {
+                write!(&mut ret, "-...-{}", subs[count - 1]).unwrap();
+            } else {
+                for i in 1..count {
+                    write!(&mut ret, "-{}", subs[i]).unwrap();
+                }
+            }
+        }
+        ret
+    }
+}
+
+impl std::fmt::Display for SID_MAX {
+    /// The full, unabbreviated SID string (e.g. `S-1-5-21-...-1001`).
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.format(false))
+    }
+}
+
+impl PartialEq for SID_MAX {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+}
+impl Eq for SID_MAX {}
+
+impl std::fmt::Debug for SID_MAX {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // The formatted SID string is more useful than the raw byte array.
+        f.debug_struct("SID_MAX")
+            .field("sid", &self.format(false))
+            .finish()
+    }
+}
+
+impl std::hash::Hash for SID_MAX {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_bytes().hash(state);
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -491,7 +639,7 @@ impl<'a> ProcessEntry<'a> {
         }
     }
 
-    /// The process user SID from the extension, as an 8-byte aligned copy.
+    /// The process user SID from the extension, as the raw `SID` bytes.
     ///
     /// `None` for a basic snapshot, for an entry that reports no SID, or when
     /// the offsets and sizes do not add up - the extension layout is not
@@ -519,7 +667,7 @@ impl<'a> ProcessEntry<'a> {
         Some(base)
     }
 
-    pub fn user_sid(&self) -> Option<Vec<u64>> {
+    pub fn user_sid(&self) -> Option<SID_MAX> {
         let base = self.extension_base()?;
 
         // SAFETY: `extension_base` already verified `base + prefix <= end`.
@@ -566,10 +714,10 @@ impl<'a> ProcessEntry<'a> {
 
 /// Copies the SID at byte `offset` (bounded by `end`) out of `base`.
 ///
-/// Returned as `Vec<u64>` because a SID is read back through `PSID`, whose
-/// sub-authorities are `u32`: they have to stay aligned, and a byte vector
-/// only guarantees 1.
-fn copy_sid(base: *const u8, offset: usize, end: usize) -> Option<Vec<u64>> {
+/// Returned as an owned [`SID_MAX`], which can be handed straight back to
+/// `LookupAccountSidW` as a `PSID`; the sub-authorities are read unaligned, so
+/// no alignment guarantee is needed.
+fn copy_sid(base: *const u8, offset: usize, end: usize) -> Option<SID_MAX> {
     if offset.saturating_add(SID_HEADER_BYTES) > end {
         return None;
     }
@@ -592,15 +740,23 @@ fn copy_sid(base: *const u8, offset: usize, end: usize) -> Option<Vec<u64>> {
         return None;
     }
 
-    let mut words = vec![0u64; bytes.div_ceil(size_of::<u64>())];
-    // SAFETY: `words` is `bytes` rounded up, and `offset + bytes <= end`, so
-    // the copy stays inside both allocations. `base` and `words` do not
-    // overlap.
+    let mut sid = SID_MAX {
+        sid: SID::default(),
+        _pad: [0u8; SECURITY_MAX_SID_SIZE as usize - size_of::<SID>()],
+    };
+    // SAFETY: `sid` is `SECURITY_MAX_SID_SIZE` bytes, and `offset + bytes <=
+    // end`, so the copy stays inside both allocations. `base` and `sid` do not
+    // overlap. Copying the whole live SID by bytes lands the header and all
+    // sub-authorities into `sid` even though `SID` only declares one.
     unsafe {
-        ptr::copy_nonoverlapping(base.add(offset), words.as_mut_ptr().cast::<u8>(), bytes);
+        ptr::copy_nonoverlapping(
+            base.add(offset),
+            (&mut sid.sid as *mut SID).cast::<u8>(),
+            bytes,
+        );
     }
 
-    Some(words)
+    Some(sid)
 }
 
 /// Walks the entries of a [`SystemProcessSnapshot`].
@@ -834,13 +990,13 @@ mod tests {
     #[test]
     fn full_snapshot_resolves_user_sid() {
         let sid = sid_local_system();
-        let expected = sid_as_words(&sid);
         let snap = make_snapshot(&sid, 0);
 
         let mut iter = snap.iter();
         let entry = iter.next().expect("one entry");
         assert_eq!(entry.info().UniqueProcessId as usize, 1234);
-        assert_eq!(entry.user_sid(), Some(expected));
+        let got = entry.user_sid().expect("a user SID");
+        assert_eq!(got.as_bytes(), sid);
         assert!(iter.next().is_none());
     }
 

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -6,7 +6,8 @@
 //! the header, hence the `non_snake_case` allowances.
 
 use std::ffi::c_void;
-use std::mem::{align_of, size_of};
+use std::marker::PhantomData;
+use std::mem::{offset_of, size_of};
 use std::ptr;
 use std::sync::OnceLock;
 
@@ -94,37 +95,87 @@ pub struct SYSTEM_PROCESS_INFORMATION {
     // String buffer for `ImageName`
 }
 
+/// `SYSTEM_EXTENDED_THREAD_INFORMATION` - the thread record used by
+/// `SystemExtendedProcessInformation` (57) and `SystemFullProcessInformation`
+/// (148) in place of `SYSTEM_THREADS`.
+///
+/// The leading union member is a plain `SYSTEM_THREADS`, which is the only
+/// part this crate reads; the trailing pointers are here so the array stride
+/// (used to locate the process extension) is the real one.
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct SYSTEM_EXTENDED_THREAD_INFORMATION {
+    pub ThreadInfo: SYSTEM_THREADS,
+    pub StackBase: *mut c_void,
+    pub StackLimit: *mut c_void,
+    pub Win32StartAddress: *mut c_void,
+    /// The base address of the memory region containing the TEB. Since VISTA.
+    pub TebBaseAddress: *mut c_void,
+    pub Reserved2: usize,
+    pub Reserved3: usize,
+    pub Reserved4: usize,
+}
+
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(size_of::<SYSTEM_PROCESS_INFORMATION>() == 256);
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(size_of::<SYSTEM_THREADS>() == 80);
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(size_of::<SYSTEM_EXTENDED_THREAD_INFORMATION>() == 136);
 
-impl SYSTEM_PROCESS_INFORMATION {
-    /// Borrows the `Threads[]` flexible array trailing this process header.
-    ///
-    /// `NumberOfThreads` is the count the kernel stored, and for every entry
-    /// except the last the following `SYSTEM_PROCESS_INFORMATION` (at
-    /// `NextEntryOffset`) bounds the array, so the slice can never overreach
-    /// the next entry. The last entry has `NextEntryOffset == 0`; there the
-    /// buffer is sized by the kernel for exactly `NumberOfThreads` entries.
-    pub fn threads(&self) -> ThreadSlice<'_> {
-        let aligned = (self.Threads.as_ptr() as usize) % align_of::<SYSTEM_THREADS>() == 0;
-        let len = if aligned {
-            self.NumberOfThreads as usize
-        } else {
-            0
-        };
-        // SAFETY: `Threads` is the C99 flexible array member. `self` lives in
-        // a live snapshot buffer and `len` is the count the kernel reported, so
-        // the `len` `SYSTEM_THREADS` following the header are valid and the
-        // pointer is aligned (verified above).
-        let threads = unsafe { std::slice::from_raw_parts(self.Threads.as_ptr(), len) };
-        ThreadSlice {
-            threads,
-            pid: self.UniqueProcessId as usize,
-        }
-    }
+/// `PROCESS_DISK_COUNTERS`
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct PROCESS_DISK_COUNTERS {
+    pub BytesRead: u64,
+    pub BytesWritten: u64,
+    pub ReadOperationCount: u64,
+    pub WriteOperationCount: u64,
+    pub FlushOperationCount: u64,
 }
+
+/// The leading, version-stable part of `SYSTEM_PROCESS_INFORMATION_EXTENSION`,
+/// as returned by `SystemFullProcessInformation` (148).
+///
+/// Only the prefix is declared. Everything after `PackageFullNameOffset` -
+/// `PROCESS_ENERGY_VALUES` and the fields behind it - has been resized and
+/// reordered repeatedly across Windows 10 and 11 builds; measured sizes on
+/// this machine are 368 bytes and up, so neither the trailing fields nor
+/// `size_of` of the whole structure can be relied on. The variable-length
+/// data the offsets point at sits *past* the real structure and is reached
+/// purely through those offsets, which is why they are all this crate needs.
+///
+/// Only `UserSidOffset` is read today; the rest documents the layout and
+/// guards the offsets with the assertions below.
+#[repr(C)]
+#[allow(non_snake_case)]
+#[allow(dead_code)]
+pub struct SYSTEM_PROCESS_INFORMATION_EXTENSION {
+    pub DiskCounters: PROCESS_DISK_COUNTERS,
+    pub ContextSwitches: u64,
+    /// `HasStrongId` / `Classification` / `BackgroundActivityModerated` bits.
+    pub Flags: u32,
+    /// Byte offset from the start of this structure to the user SID, or 0.
+    pub UserSidOffset: u32,
+    /// Byte offset from the start of this structure to the package name, or 0.
+    pub PackageFullNameOffset: u32,
+}
+
+const _: () = assert!(offset_of!(SYSTEM_PROCESS_INFORMATION_EXTENSION, DiskCounters) == 0);
+const _: () = assert!(offset_of!(SYSTEM_PROCESS_INFORMATION_EXTENSION, ContextSwitches) == 40);
+const _: () = assert!(offset_of!(SYSTEM_PROCESS_INFORMATION_EXTENSION, Flags) == 48);
+const _: () = assert!(offset_of!(SYSTEM_PROCESS_INFORMATION_EXTENSION, UserSidOffset) == 52);
+const _: () =
+    assert!(offset_of!(SYSTEM_PROCESS_INFORMATION_EXTENSION, PackageFullNameOffset) == 56);
+const _: () = assert!(size_of::<SYSTEM_PROCESS_INFORMATION_EXTENSION>() == 64);
+
+/// Fixed part of a `SID`: revision, sub-authority count and the 6-byte
+/// identifier authority. `windows-sys` types the trailing sub-authorities as
+/// `[u32; 1]`, so `size_of::<SID>()` is 4 bytes more than this.
+const SID_HEADER_BYTES: usize = 8;
+const SID_REVISION: u8 = 1;
+/// `SID_MAX_SUB_AUTHORITIES`
+const SID_MAX_SUB_AUTHORITIES: usize = 15;
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -132,7 +183,11 @@ impl SYSTEM_PROCESS_INFORMATION {
 
 /// SystemInformationClass
 pub const SYSTEM_PROCESS_INFORMATION_CLASS: u32 = 5;
-/// ProcessInformationClass
+/// SystemInformationClass. Windows 8.1 and newer, and the caller has to be
+/// elevated: without it the query returns `STATUS_ACCESS_DENIED`. Carries
+/// the process extension, which includes the user SID.
+pub const SYSTEM_FULL_PROCESS_INFORMATION_CLASS: u32 = 148;
+/// ProcessInformationClass. Windows 8.1 and newer
 pub const PROCESS_COMMAND_LINE_INFORMATION_CLASS: u32 = 60;
 /// NTSTATUS
 pub const STATUS_SUCCESS: i32 = 0;
@@ -208,22 +263,83 @@ pub fn nt_query_information_process() -> Option<NtQueryInformationProcessFn> {
 // SystemProcessInformation
 // ---------------------------------------------------------------------------
 
-const INITIAL_BUF: usize = 64 * 1024;
+/// Which information class produced a snapshot.
+///
+/// This decides how the entries are laid out: `Full` carries the wider thread
+/// records and a `SYSTEM_PROCESS_INFORMATION_EXTENSION` after them.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotKind {
+    /// `SystemProcessInformation` (5): always available.
+    Basic,
+    /// `SystemFullProcessInformation` (148): Windows 8.1 and elevation.
+    Full,
+}
 
-/// Takes one `SystemProcessInformation` snapshot.
+impl SnapshotKind {
+    /// Distance between two thread records of this snapshot.
+    fn thread_stride(self) -> usize {
+        match self {
+            Self::Basic => size_of::<SYSTEM_THREADS>(),
+            Self::Full => size_of::<SYSTEM_EXTENDED_THREAD_INFORMATION>(),
+        }
+    }
+
+    /// Whether each entry carries a `SYSTEM_PROCESS_INFORMATION_EXTENSION`.
+    fn has_extension(self) -> bool {
+        match self {
+            Self::Basic => false,
+            Self::Full => true,
+        }
+    }
+}
+
+/// A process snapshot: the buffer the kernel filled plus the class that did it.
+pub struct SystemProcessSnapshot {
+    words: Vec<u64>,
+    kind: SnapshotKind,
+}
+
+impl SystemProcessSnapshot {
+    pub fn iter(&self) -> ProcessIter<'_> {
+        ProcessIter::new(self)
+    }
+}
+
+/// Takes one process snapshot.
+///
+/// `SystemFullProcessInformation` is tried first: it carries the process user
+/// SID, which saves an `OpenProcessToken` per process. Any failure - an older
+/// Windows that does not know the class, or a caller without the privilege it
+/// requires - is reported as a negative status, so we quietly fall back to the
+/// basic class.
 ///
 /// The buffer is a `Vec<u64>` rather than a `Vec<u8>` because the structures
 /// require 8-byte alignment and a byte vector only guarantees 1.
-pub fn query_system_processes() -> Option<Vec<u64>> {
+pub fn query_system_processes() -> Option<SystemProcessSnapshot> {
+    if let Some(words) = query_system_info_class(SYSTEM_FULL_PROCESS_INFORMATION_CLASS) {
+        return Some(SystemProcessSnapshot {
+            words,
+            kind: SnapshotKind::Full,
+        });
+    }
+
+    let words = query_system_info_class(SYSTEM_PROCESS_INFORMATION_CLASS)?;
+    Some(SystemProcessSnapshot {
+        words,
+        kind: SnapshotKind::Basic,
+    })
+}
+
+fn query_system_info_class(class: u32) -> Option<Vec<u64>> {
     let query = nt_query_system_information()?;
-    let mut words = vec![0u64; INITIAL_BUF / size_of::<u64>()];
+    let mut words = vec![0u64; 0];
 
     for _ in 0..8 {
         let mut ret_len: u32 = 0;
         let len = words.len() * size_of::<u64>();
         let status = unsafe {
             query(
-                SYSTEM_PROCESS_INFORMATION_CLASS,
+                class,
                 words.as_mut_ptr().cast::<c_void>(),
                 len as u32,
                 ptr::addr_of_mut!(ret_len),
@@ -255,20 +371,40 @@ pub struct ThreadInfo {
     pub priority: i32,
 }
 
-/// The `SYSTEM_THREADS` array trailing a `SYSTEM_PROCESS_INFORMATION`.
+/// The thread records trailing a `SYSTEM_PROCESS_INFORMATION`.
+///
+/// Held as a base pointer plus a stride rather than a `&[SYSTEM_THREADS]`:
+/// the records are `SYSTEM_EXTENDED_THREAD_INFORMATION` (136 bytes) in a full
+/// snapshot, of which only the leading `SYSTEM_THREADS` part is read, and
+/// neither variant is guaranteed to sit on an 8-byte boundary.
 pub struct ThreadSlice<'a> {
-    threads: &'a [SYSTEM_THREADS],
+    base: *const u8,
+    stride: usize,
+    len: usize,
     /// Owning process id, used to confirm the layout is what we expect.
     pid: usize,
+    _lifetime: PhantomData<&'a [u64]>,
 }
 
 impl ThreadSlice<'_> {
     pub fn len(&self) -> usize {
-        self.threads.len()
+        self.len
     }
 
     pub fn get(&self, index: usize) -> Option<ThreadInfo> {
-        let thread = self.threads.get(index)?;
+        if index >= self.len {
+            return None;
+        }
+
+        // SAFETY: `index < len` and `len` was clamped so that
+        // `base + (len - 1) * stride + size_of` stays inside the entry. The
+        // record is copied because it can be misaligned.
+        let thread: SYSTEM_THREADS = unsafe {
+            self.base
+                .add(index * self.stride)
+                .cast::<SYSTEM_THREADS>()
+                .read_unaligned()
+        };
 
         // Every thread carries its owning process id. If a future Windows
         // release moves the fields around this will not match, and the entry is
@@ -287,27 +423,209 @@ impl ThreadSlice<'_> {
     }
 }
 
-/// Walks the `SYSTEM_PROCESS_INFORMATION` entries of a buffer returned by
-/// [`query_system_processes`].
-pub struct ProcessIter<'a> {
+/// One entry of a snapshot: the process header plus everything that depends on
+/// knowing where the entry begins and ends.
+///
+/// The header is a copy rather than a borrow. Entries of a full snapshot are
+/// only guaranteed to be even-aligned - variable-length data such as a package
+/// name makes `NextEntryOffset` arbitrary - so a `&SYSTEM_PROCESS_INFORMATION`
+/// over the buffer would be misaligned often enough to matter.
+pub struct ProcessEntry<'a> {
     buf: &'a [u64],
+    /// Unaligned copy of the entry's leading `SYSTEM_PROCESS_INFORMATION`.
+    header: SYSTEM_PROCESS_INFORMATION,
+    /// Byte offset of this entry within `buf`.
+    start: usize,
+    /// Byte offset one past this entry: the bound for its variable-length data.
+    end: usize,
+    kind: SnapshotKind,
+}
+
+impl<'a> ProcessEntry<'a> {
+    pub fn info(&self) -> &SYSTEM_PROCESS_INFORMATION {
+        &self.header
+    }
+
+    /// The `ImageName`, reduced to the file name when the snapshot supplied a
+    /// full path.
+    ///
+    /// `SystemFullProcessInformation` reports
+    /// `\Device\HarddiskVolumeN\...\foo.exe` where `SystemProcessInformation`
+    /// reports `foo.exe`. The command column falls back to this for processes
+    /// whose command line cannot be read, and the kernel-thread heuristic
+    /// looks for a '.', so both classes are normalised to the short form -
+    /// output must not change just because the caller happened to be elevated.
+    pub fn image_name(&self) -> String {
+        let name = unicode_string_to_owned(&self.header.ImageName);
+        match self.kind {
+            SnapshotKind::Basic => name,
+            SnapshotKind::Full => match name.rsplit('\\').next() {
+                Some(file) if !file.is_empty() => file.to_owned(),
+                _ => name,
+            },
+        }
+    }
+
+    /// The `Threads[]` flexible array trailing the process header.
+    ///
+    /// `NumberOfThreads` is the count the kernel stored. For every entry except
+    /// the last, the following entry (at `NextEntryOffset`) bounds the array;
+    /// the last entry has `NextEntryOffset == 0` and is bounded by the buffer,
+    /// which the kernel sized for exactly `NumberOfThreads` records.
+    pub fn threads(&self) -> ThreadSlice<'a> {
+        let header = size_of::<SYSTEM_PROCESS_INFORMATION>();
+        let stride = self.kind.thread_stride();
+        let first = self.start.saturating_add(header);
+
+        let available = self.end.saturating_sub(first);
+        let wanted = (self.header.NumberOfThreads as usize).saturating_mul(stride);
+        let len = wanted.min(available) / stride;
+
+        ThreadSlice {
+            // SAFETY: `first` is inside `buf`, which outlives `'a`.
+            base: unsafe { self.buf.as_ptr().cast::<u8>().add(first) },
+            stride,
+            len,
+            pid: self.header.UniqueProcessId as usize,
+            _lifetime: PhantomData,
+        }
+    }
+
+    /// The process user SID from the extension, as an 8-byte aligned copy.
+    ///
+    /// `None` for a basic snapshot, for an entry that reports no SID, or when
+    /// the offsets and sizes do not add up - the extension layout is not
+    /// version-stable, so nothing here is trusted before it is checked.
+    /// Byte offset of this entry's `SYSTEM_PROCESS_INFORMATION_EXTENSION`, with
+    /// the bounds already checked. `None` when the snapshot carried no extension
+    /// (a basic class-5 snapshot) or the entry is too short to hold the prefix.
+    fn extension_base(&self) -> Option<usize> {
+        if !self.kind.has_extension() {
+            return None;
+        }
+        let header = size_of::<SYSTEM_PROCESS_INFORMATION>();
+        let stride = self.kind.thread_stride();
+        let base = self
+            .start
+            .checked_add(header)?
+            .checked_add((self.header.NumberOfThreads as usize).checked_mul(stride)?)?;
+
+        // The fixed prefix we read must fit inside the entry; the variable
+        // length data trailing it is reached only through the offsets.
+        let prefix = size_of::<SYSTEM_PROCESS_INFORMATION_EXTENSION>();
+        if base.saturating_add(prefix) > self.end {
+            return None;
+        }
+        Some(base)
+    }
+
+    pub fn user_sid(&self) -> Option<Vec<u64>> {
+        let base = self.extension_base()?;
+
+        // SAFETY: `extension_base` already verified `base + prefix <= end`.
+        let fields: SYSTEM_PROCESS_INFORMATION_EXTENSION = unsafe {
+            self.buf
+                .as_ptr()
+                .cast::<u8>()
+                .add(base)
+                .cast::<SYSTEM_PROCESS_INFORMATION_EXTENSION>()
+                .read_unaligned()
+        };
+
+        if fields.UserSidOffset == 0 {
+            return None;
+        }
+
+        let offset = base.checked_add(fields.UserSidOffset as usize)?;
+        copy_sid(self.buf.as_ptr().cast::<u8>(), offset, self.end)
+    }
+
+    /// The kernel process classification (`SYSTEM_PROCESS_CLASSIFICATION`),
+    /// decoded from the low four bits of `Flags` (bit 0 is `HasStrongId`).
+    ///
+    /// Only a full snapshot carries the extension, so this is `None` for a
+    /// basic class-5 snapshot. A non-zero value marks the kernel's own
+    /// processes - System, Secure System, Registry, Memory Compression - as
+    /// opposed to normal user processes (value 0). `procs` uses this to hide
+    /// kernel threads unless `--thread` is given.
+    pub fn classification(&self) -> Option<u32> {
+        let base = self.extension_base()?;
+        // `Flags` sits at offset 48 within the extension; `Classification` is
+        // its bits 1..=4.
+        let flags: u32 = unsafe {
+            self.buf
+                .as_ptr()
+                .cast::<u8>()
+                .add(base + offset_of!(SYSTEM_PROCESS_INFORMATION_EXTENSION, Flags))
+                .cast::<u32>()
+                .read_unaligned()
+        };
+        Some((flags >> 1) & 0xF)
+    }
+}
+
+/// Copies the SID at byte `offset` (bounded by `end`) out of `base`.
+///
+/// Returned as `Vec<u64>` because a SID is read back through `PSID`, whose
+/// sub-authorities are `u32`: they have to stay aligned, and a byte vector
+/// only guarantees 1.
+fn copy_sid(base: *const u8, offset: usize, end: usize) -> Option<Vec<u64>> {
+    if offset.saturating_add(SID_HEADER_BYTES) > end {
+        return None;
+    }
+
+    // SAFETY: `offset + 8 <= end <= buf.len()` was just checked. Read as bytes
+    // rather than through `SID`: the record can be misaligned.
+    let revision = unsafe { base.add(offset).read() };
+    let count = unsafe { base.add(offset + 1).read() };
+    if revision != SID_REVISION {
+        return None;
+    }
+
+    let sub_authorities = usize::from(count);
+    if sub_authorities > SID_MAX_SUB_AUTHORITIES {
+        return None;
+    }
+
+    let bytes = SID_HEADER_BYTES + sub_authorities * size_of::<u32>();
+    if offset.saturating_add(bytes) > end {
+        return None;
+    }
+
+    let mut words = vec![0u64; bytes.div_ceil(size_of::<u64>())];
+    // SAFETY: `words` is `bytes` rounded up, and `offset + bytes <= end`, so
+    // the copy stays inside both allocations. `base` and `words` do not
+    // overlap.
+    unsafe {
+        ptr::copy_nonoverlapping(base.add(offset), words.as_mut_ptr().cast::<u8>(), bytes);
+    }
+
+    Some(words)
+}
+
+/// Walks the entries of a [`SystemProcessSnapshot`].
+pub struct ProcessIter<'a> {
+    snapshot: &'a SystemProcessSnapshot,
     offset: usize,
 }
 
 impl<'a> ProcessIter<'a> {
-    pub fn new(buf: &'a [u64]) -> Self {
-        Self { buf, offset: 0 }
+    fn new(snapshot: &'a SystemProcessSnapshot) -> Self {
+        Self {
+            snapshot,
+            offset: 0,
+        }
     }
 
     fn byte_len(&self) -> usize {
-        std::mem::size_of_val(self.buf)
+        self.snapshot.words.len() * size_of::<u64>()
     }
 }
 
 impl<'a> Iterator for ProcessIter<'a> {
-    type Item = &'a SYSTEM_PROCESS_INFORMATION;
+    type Item = ProcessEntry<'a>;
 
-    fn next(&mut self) -> Option<&'a SYSTEM_PROCESS_INFORMATION> {
+    fn next(&mut self) -> Option<ProcessEntry<'a>> {
         let limit = self.byte_len();
         let offset = self.offset;
         let header = size_of::<SYSTEM_PROCESS_INFORMATION>();
@@ -315,22 +633,40 @@ impl<'a> Iterator for ProcessIter<'a> {
             return None;
         }
 
-        let base = self.buf.as_ptr() as *const u8;
-        // SAFETY: the buffer is 8-byte aligned and `offset` only ever advances
-        // by `NextEntryOffset`, which keeps each entry aligned.
-        let info: &'a SYSTEM_PROCESS_INFORMATION =
-            unsafe { &*base.add(offset).cast::<SYSTEM_PROCESS_INFORMATION>() };
-
-        // `NextEntryOffset == 0` marks the last entry. Anything that would
-        // rewind, or leave the next entry misaligned, is malformed - stop
-        // rather than loop forever or dereference a bad pointer.
-        self.offset = match info.NextEntryOffset as usize {
-            0 => limit,
-            next if next < header || next % align_of::<SYSTEM_PROCESS_INFORMATION>() != 0 => limit,
-            next => offset.saturating_add(next),
+        // SAFETY: `offset + size_of <= limit`, so the header lies wholly inside
+        // the buffer. Copied rather than borrowed: entries of a full snapshot
+        // are not guaranteed to be 8-byte aligned.
+        let info: SYSTEM_PROCESS_INFORMATION = unsafe {
+            self.snapshot
+                .words
+                .as_ptr()
+                .cast::<u8>()
+                .add(offset)
+                .cast::<SYSTEM_PROCESS_INFORMATION>()
+                .read_unaligned()
         };
 
-        Some(info)
+        // `NextEntryOffset == 0` marks the last entry. An offset that would not
+        // move past this header is malformed - stop rather than loop forever.
+        // Alignment is deliberately not required: a full snapshot pads entries
+        // to 2 bytes, so demanding 8 would silently truncate the process list.
+        let next = info.NextEntryOffset as usize;
+        let end = if next == 0 {
+            limit
+        } else if next < header {
+            limit
+        } else {
+            offset.saturating_add(next).min(limit)
+        };
+        self.offset = end;
+
+        Some(ProcessEntry {
+            buf: &self.snapshot.words,
+            header: info,
+            start: offset,
+            end,
+            kind: self.snapshot.kind,
+        })
     }
 }
 
@@ -417,4 +753,182 @@ pub fn unicode_string_to_owned(string: &UNICODE_STRING) -> String {
     // the `'a` of the `ProcessEntry` this came from.
     let slice = unsafe { std::slice::from_raw_parts(string.Buffer, len) };
     String::from_utf16_lossy(slice)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    /// Bytes of S-1-5-18 (Local System), as a `SID` would lay them out.
+    fn sid_local_system() -> Vec<u8> {
+        let mut bytes = vec![1u8, 2]; // Revision, SubAuthorityCount
+        bytes.extend_from_slice(&[0, 0, 0, 0, 0, 5]); // Authority
+        bytes.extend_from_slice(&5u32.to_le_bytes()); // SubAuthority[0]
+        bytes.extend_from_slice(&18u32.to_le_bytes()); // SubAuthority[1]
+        bytes
+    }
+
+    fn sid_as_words(sid: &[u8]) -> Vec<u64> {
+        let mut words = vec![0u64; sid.len().div_ceil(size_of::<u64>())];
+        // SAFETY: `words` is `sid.len()` rounded up, so the copy is in bounds.
+        unsafe {
+            ptr::copy_nonoverlapping(sid.as_ptr(), words.as_mut_ptr().cast::<u8>(), sid.len());
+        }
+        words
+    }
+
+    /// Builds a single-entry full snapshot whose user SID is `sid`, with the
+    /// SID appended right after the 64-byte extension prefix (so
+    /// `UserSidOffset == 64`). An empty `sid` drops the data and sets the
+    /// offset to 0. `flags` is written into the extension `Flags` field so
+    /// `classification()` can be exercised.
+    fn make_snapshot(sid: &[u8], flags: u32) -> SystemProcessSnapshot {
+        let mut header: SYSTEM_PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
+        header.NextEntryOffset = 0;
+        header.NumberOfThreads = 0;
+        header.UniqueProcessId = 1234 as HANDLE;
+
+        let header_bytes = unsafe {
+            std::slice::from_raw_parts(
+                &header as *const SYSTEM_PROCESS_INFORMATION as *const u8,
+                size_of::<SYSTEM_PROCESS_INFORMATION>(),
+            )
+        };
+
+        let mut ext: SYSTEM_PROCESS_INFORMATION_EXTENSION = unsafe { std::mem::zeroed() };
+        let has_sid = !sid.is_empty();
+        ext.UserSidOffset = if has_sid { 64 } else { 0 };
+        ext.Flags = flags;
+
+        let ext_bytes = unsafe {
+            std::slice::from_raw_parts(
+                &ext as *const SYSTEM_PROCESS_INFORMATION_EXTENSION as *const u8,
+                size_of::<SYSTEM_PROCESS_INFORMATION_EXTENSION>(),
+            )
+        };
+
+        let mut bytes: Vec<u8> = Vec::with_capacity(
+            size_of::<SYSTEM_PROCESS_INFORMATION>() + ext_bytes.len() + sid.len(),
+        );
+        bytes.extend_from_slice(header_bytes);
+        bytes.extend_from_slice(ext_bytes);
+        bytes.extend_from_slice(sid);
+
+        let mut words = vec![0u64; bytes.len().div_ceil(size_of::<u64>())];
+        // SAFETY: `words` is `bytes.len()` rounded up.
+        unsafe {
+            ptr::copy_nonoverlapping(bytes.as_ptr(), words.as_mut_ptr().cast::<u8>(), bytes.len());
+        }
+
+        SystemProcessSnapshot {
+            words,
+            kind: SnapshotKind::Full,
+        }
+    }
+
+    #[test]
+    fn full_snapshot_resolves_user_sid() {
+        let sid = sid_local_system();
+        let expected = sid_as_words(&sid);
+        let snap = make_snapshot(&sid, 0);
+
+        let mut iter = snap.iter();
+        let entry = iter.next().expect("one entry");
+        assert_eq!(entry.info().UniqueProcessId as usize, 1234);
+        assert_eq!(entry.user_sid(), Some(expected));
+        assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn full_snapshot_without_sid_is_none() {
+        let snap = make_snapshot(&[], 0);
+        let entry = snap.iter().next().expect("one entry");
+        assert_eq!(entry.user_sid(), None);
+    }
+
+    #[test]
+    fn truncated_sid_is_rejected() {
+        // SID data present but shorter than a full header -> bounds checked away.
+        let snap = make_snapshot(&[1, 2, 0, 0, 0, 0, 0, 5], 0);
+        let entry = snap.iter().next().expect("one entry");
+        assert_eq!(entry.user_sid(), None);
+    }
+
+    #[test]
+    fn basic_snapshot_has_no_extension() {
+        // Without the extension, `user_sid` must always be `None` regardless of
+        // the bytes that happen to follow the header.
+        let mut buf = vec![0u64; 256 / 8];
+        let snap = SystemProcessSnapshot {
+            words: buf.clone(),
+            kind: SnapshotKind::Basic,
+        };
+        assert_eq!(snap.iter().next().unwrap().user_sid(), None);
+        // Now point it at what would be a valid SID in a full snapshot.
+        let sid = sid_local_system();
+        buf.extend(sid_as_words(&sid));
+        let snap = SystemProcessSnapshot {
+            words: buf,
+            kind: SnapshotKind::Basic,
+        };
+        assert_eq!(snap.iter().next().unwrap().user_sid(), None);
+    }
+
+    #[test]
+    fn classification_normal_is_zero() {
+        // `Flags = 0` -> Classification field is 0 -> a normal user process.
+        let snap = make_snapshot(&[], 0);
+        let entry = snap.iter().next().expect("one entry");
+        assert_eq!(entry.classification(), Some(0));
+    }
+
+    #[test]
+    fn classification_skips_hasstrongid_bit() {
+        // Bit 0 of `Flags` is `HasStrongId`, not `Classification`; it must
+        // not bleed into the decoded value.
+        let snap = make_snapshot(&[], 1);
+        let entry = snap.iter().next().expect("one entry");
+        assert_eq!(entry.classification(), Some(0));
+    }
+
+    #[test]
+    fn classification_system_is_nonzero() {
+        // `Classification = System` (1) at bits 1..=4 -> `Flags = 1 << 1 = 2`.
+        let snap = make_snapshot(&[], 1 << 1);
+        let entry = snap.iter().next().expect("one entry");
+        assert_eq!(entry.classification(), Some(1));
+        assert!(entry.classification().is_some_and(|c| c != 0));
+    }
+
+    #[test]
+    fn classification_registry_nonzero() {
+        // `Classification = Registry` (4) -> `Flags = 4 << 1 = 8`.
+        let snap = make_snapshot(&[], 4 << 1);
+        let entry = snap.iter().next().expect("one entry");
+        assert_eq!(entry.classification(), Some(4));
+    }
+
+    #[test]
+    fn basic_snapshot_has_no_classification() {
+        // Only the full snapshot carries the extension, so `classification`
+        // is `None` regardless of the trailing bytes.
+        let mut buf = vec![0u64; 256 / 8];
+        let snap = SystemProcessSnapshot {
+            words: buf.clone(),
+            kind: SnapshotKind::Basic,
+        };
+        assert_eq!(snap.iter().next().unwrap().classification(), None);
+        let sid = sid_local_system();
+        buf.extend(sid_as_words(&sid));
+        let snap = SystemProcessSnapshot {
+            words: buf,
+            kind: SnapshotKind::Basic,
+        };
+        assert_eq!(snap.iter().next().unwrap().classification(), None);
+    }
 }

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -574,6 +574,78 @@ fn query_system_info_class(class: u32) -> Option<Vec<u64>> {
     None
 }
 
+/// The scheduler state of one thread, as `SYSTEM_THREAD_INFORMATION` reports
+/// it.
+///
+/// Both values are kept raw. `WaitReason` is a leftover from the last wait once
+/// a thread is no longer waiting, so it only means anything while `State` is
+/// `Waiting`; turning the pair into a display letter is the State column's job.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ThreadState {
+    /// `KTHREAD_STATE`.
+    pub state: u32,
+    /// `KWAIT_REASON`.
+    pub wait_reason: u32,
+}
+
+/// `KTHREAD_STATE`, as reported by `SYSTEM_THREAD_INFORMATION::State`.
+///
+/// <https://ntdoc.m417z.com/kthread_state>
+pub mod thread_state {
+    pub const INITIALIZED: u32 = 0;
+    pub const READY: u32 = 1;
+    pub const RUNNING: u32 = 2;
+    pub const STANDBY: u32 = 3;
+    pub const TERMINATED: u32 = 4;
+    pub const WAITING: u32 = 5;
+    pub const TRANSITION: u32 = 6;
+    pub const DEFERRED_READY: u32 = 7;
+    /// No longer produced by the kernel; kept so the table stays complete.
+    pub const GATE_WAIT: u32 = 8;
+    pub const WAITING_FOR_PROCESS_IN_SWAP: u32 = 9;
+}
+
+/// The `KWAIT_REASON` values that mark a thread stopped rather than waiting
+/// for something.
+///
+/// <https://ntdoc.m417z.com/kwait_reason>
+pub mod wait_reason {
+    /// Set by `NtSuspendThread`.
+    pub const SUSPENDED: u32 = 5;
+    pub const WR_SUSPENDED: u32 = 12;
+}
+
+/// The state pair of one raw thread record.
+fn decode_state(thread: &SYSTEM_THREAD_INFORMATION) -> ThreadState {
+    ThreadState {
+        state: thread.State,
+        wait_reason: thread.WaitReason,
+    }
+}
+
+/// How active a thread is; lower wins.
+///
+/// The order mirrors the State column's letters: runnable beats waiting,
+/// waiting beats suspended, suspended beats terminated, and anything the
+/// kernel has not been seen to produce is least active. `WaitReason` only
+/// matters while the thread is `WAITING` - it is a leftover from the last
+/// wait otherwise.
+fn activity(state: ThreadState) -> u8 {
+    use thread_state::*;
+
+    match state.state {
+        // Runnable, or on its way there: `TRANSITION` only means the kernel
+        // stack is still being brought in.
+        INITIALIZED | READY | RUNNING | STANDBY | TRANSITION | DEFERRED_READY => 0,
+        WAITING | GATE_WAIT | WAITING_FOR_PROCESS_IN_SWAP => match state.wait_reason {
+            wait_reason::SUSPENDED | wait_reason::WR_SUSPENDED => 2,
+            _ => 1,
+        },
+        TERMINATED => 3,
+        _ => 4,
+    }
+}
+
 /// One thread of a process, decoded from a `SYSTEM_THREAD_INFORMATION`.
 ///
 /// The raw handles are narrowed to ids and the times are converted, so this is
@@ -588,6 +660,8 @@ pub struct ThreadSnapshot {
     pub kernel_time: u64,
     pub user_time: u64,
     pub priority: i32,
+    /// Raw scheduler state at the moment of the snapshot.
+    pub state: ThreadState,
 }
 
 /// One entry of a snapshot: the process header plus everything that depends on
@@ -644,21 +718,8 @@ impl<'a> ProcessEntry<'a> {
     /// that would reach past the entry are clipped, so nothing is read outside
     /// the entry it belongs to.
     pub fn threads(&self) -> Vec<ThreadSnapshot> {
-        let stride = self.kind.thread_stride();
-        let first = self
-            .start
-            .saturating_add(size_of::<SYSTEM_PROCESS_INFORMATION>());
-
-        let available = self.end.saturating_sub(first);
-        let wanted = (self.info.NumberOfThreads as usize).saturating_mul(stride);
-        let len = wanted.min(available) / stride;
-
+        let (base, stride, len) = self.threads_span();
         let mut ret = Vec::with_capacity(len);
-        // `info` borrows the entry that starts at `start`, so this is
-        // `start + 256`: inside the buffer, and 8-byte aligned like every
-        // entry. Each stride is a multiple of 8, so every record is aligned
-        // too, and `len` was clamped so the last one stays inside the entry.
-        let base = self.info.Threads.as_ptr().cast::<u8>();
         let pid = self.info.UniqueProcessId as usize as i32;
 
         for index in 0..len {
@@ -677,10 +738,67 @@ impl<'a> ProcessEntry<'a> {
                 kernel_time: thread.KernelTime as u64,
                 user_time: thread.UserTime as u64,
                 priority: thread.Priority,
+                state: decode_state(thread),
             });
         }
 
         ret
+    }
+
+    /// The `Threads[]` flexible array as a raw span: the first record, the
+    /// distance between two records, and how many of them may be read.
+    ///
+    /// `NumberOfThreads` is the count the kernel stored, but only the records
+    /// that fit between the process header and the end of this entry can be
+    /// read, so the two are reconciled here and every caller gets the clamped
+    /// count.
+    fn threads_span(&self) -> (*const u8, usize, usize) {
+        let stride = self.kind.thread_stride();
+        let first = self
+            .start
+            .saturating_add(size_of::<SYSTEM_PROCESS_INFORMATION>());
+
+        let available = self.end.saturating_sub(first);
+        let wanted = (self.info.NumberOfThreads as usize).saturating_mul(stride);
+        let len = wanted.min(available) / stride;
+
+        // `info` borrows the entry that starts at `start`, so this is
+        // `start + 256`: inside the buffer, and 8-byte aligned like every
+        // entry. Each stride is a multiple of 8, so every record is aligned
+        // too, and `len` was clamped so the last one stays inside the entry.
+        (self.info.Threads.as_ptr().cast::<u8>(), stride, len)
+    }
+
+    /// The scheduler state of the most active thread of this entry.
+    ///
+    /// `SYSTEM_PROCESS_INFORMATION` carries no state for the process itself, so
+    /// the per-thread states are the only thing a process state can be derived
+    /// from. The most active thread wins, in the same order the State column
+    /// prints its letters; the letter mapping itself stays in the column.
+    /// `None` when no thread record could be read; the caller separates a
+    /// terminated process from an unreadable one with `NumberOfThreads`.
+    pub fn state(&self) -> Option<ThreadState> {
+        let (base, stride, len) = self.threads_span();
+        let mut best: Option<ThreadState> = None;
+        let mut best_rank = u8::MAX;
+
+        for index in 0..len {
+            // SAFETY: `base + index * stride` is inside the entry (`index <
+            // len`) and 8-byte aligned, so a `&SYSTEM_THREAD_INFORMATION`
+            // over it is valid. Both record types start with that structure
+            // (see the `ThreadInfo` offset assertion), which is why the stride
+            // is the only thing that differs between the two classes.
+            let thread: &SYSTEM_THREAD_INFORMATION =
+                unsafe { &*base.add(index * stride).cast::<SYSTEM_THREAD_INFORMATION>() };
+            let state = decode_state(thread);
+            let rank = activity(state);
+            if rank < best_rank {
+                best_rank = rank;
+                best = Some(state);
+            }
+        }
+
+        best
     }
 
     /// The process user SID from the extension, as the raw `SID` bytes.
@@ -1279,6 +1397,117 @@ mod tests {
         let got = entry.threads();
         assert_eq!(got.len(), 2);
         assert_eq!(got[1].tid, 12);
+    }
+
+    /// A thread record sitting in a given `KTHREAD_STATE` / `KWAIT_REASON`.
+    fn thread_record_in(
+        tid: usize,
+        pid: usize,
+        state: u32,
+        wait_reason: u32,
+    ) -> SYSTEM_THREAD_INFORMATION {
+        let mut thread = thread_record(tid, pid);
+        thread.State = state;
+        thread.WaitReason = wait_reason;
+        thread
+    }
+
+    #[test]
+    fn state_picks_the_most_active_thread() {
+        // `Running` beats `Waiting`, which beats `Terminated`.
+        let records = [
+            thread_record_in(11, 1234, thread_state::WAITING, 13),
+            thread_record_in(12, 1234, thread_state::TERMINATED, 0),
+            thread_record_in(13, 1234, thread_state::RUNNING, 0),
+        ];
+        let snap = make_snapshot_with_threads(&records, 3, SnapshotKind::Basic);
+        let entry = snap.iter().next().expect("one entry");
+
+        assert_eq!(
+            entry.state(),
+            Some(ThreadState {
+                state: thread_state::RUNNING,
+                wait_reason: 0
+            })
+        );
+        // The full record carries the same pair, so a `--thread` row and the
+        // process it belongs to cannot disagree.
+        assert_eq!(
+            entry.threads()[2].state,
+            ThreadState {
+                state: thread_state::RUNNING,
+                wait_reason: 0
+            }
+        );
+    }
+
+    #[test]
+    fn state_prefers_waiting_over_suspended() {
+        // A suspended thread waits, and says why; a plain wait is more active.
+        let records = [
+            thread_record_in(11, 1234, thread_state::WAITING, wait_reason::SUSPENDED),
+            thread_record_in(12, 1234, thread_state::WAITING, 13),
+        ];
+        let snap = make_snapshot_with_threads(&records, 2, SnapshotKind::Basic);
+        let entry = snap.iter().next().expect("one entry");
+
+        assert_eq!(
+            entry.state(),
+            Some(ThreadState {
+                state: thread_state::WAITING,
+                wait_reason: 13
+            })
+        );
+    }
+
+    #[test]
+    fn state_of_a_full_snapshot_uses_the_wider_stride() {
+        // The state words live at the start of `SYSTEM_EXTENDED_THREAD_INFORMATION`,
+        // so reading them means stepping by 136 rather than 80.
+        let records = [
+            extend(thread_record_in(11, 1234, thread_state::TERMINATED, 0)),
+            extend(thread_record_in(12, 1234, thread_state::WAITING, 12)),
+        ];
+        let snap = make_snapshot_with_threads(&records, 2, SnapshotKind::Full);
+        let entry = snap.iter().next().expect("one entry");
+
+        assert_eq!(
+            entry.state(),
+            Some(ThreadState {
+                state: thread_state::WAITING,
+                wait_reason: 12
+            })
+        );
+    }
+
+    #[test]
+    fn state_is_none_without_records() {
+        // A process whose threads have all exited decodes to no state at all,
+        // which is what lets the State column call it terminated.
+        let snap =
+            make_snapshot_with_threads::<SYSTEM_THREAD_INFORMATION>(&[], 0, SnapshotKind::Basic);
+        let entry = snap.iter().next().expect("one entry");
+        assert_eq!(entry.state(), None);
+    }
+
+    #[test]
+    fn state_is_clipped_to_the_entry() {
+        // Same bound as `threads`: a record past the end of the entry is not
+        // read even though the header claims it.
+        let records = [
+            thread_record_in(11, 1234, thread_state::RUNNING, 0),
+            thread_record_in(12, 1234, thread_state::WAITING, 0),
+        ];
+        let snap = make_snapshot_with_threads(&records, 3, SnapshotKind::Basic);
+        let entry = snap.iter().next().expect("one entry");
+
+        assert_eq!(
+            entry.state(),
+            Some(ThreadState {
+                state: thread_state::RUNNING,
+                wait_reason: 0
+            })
+        );
     }
 
     #[test]

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -546,8 +546,9 @@ impl SystemProcessSnapshot {
 /// requires - is reported as a negative status, so we quietly fall back to the
 /// basic class.
 ///
-/// The buffer is a `Vec<u64>` rather than a `Vec<u8>` because the structures
-/// require 8-byte alignment and a byte vector only guarantees 1.
+/// The buffer is a `Vec<u64>` rather than a `Vec<u8>` so the kernel's
+/// 8-byte-aligned entries stay aligned; the entries themselves are read
+/// unaligned, so a byte vector would work too.
 pub fn query_system_processes() -> Option<SystemProcessSnapshot> {
     if let Some(words) = query_system_info_class(SYSTEM_FULL_PROCESS_INFORMATION_CLASS) {
         return Some(SystemProcessSnapshot {
@@ -690,15 +691,14 @@ pub struct ThreadSnapshot {
 /// One entry of a snapshot: the process header plus everything that depends on
 /// knowing where the entry begins and ends.
 ///
-/// The header is borrowed straight from the `Vec<u64>` snapshot rather than
-/// copied. The buffer is 8-byte aligned (it is a `Vec<u64>`), and the kernel
-/// places each entry on an 8-byte boundary (`NextEntryOffset` is a multiple of
-/// 8), so a `&SYSTEM_PROCESS_INFORMATION` over the buffer is always aligned.
+/// The header is a copy rather than a borrow. Entries of a full snapshot are
+/// only guaranteed to be even-aligned - variable-length data such as a package
+/// name makes `NextEntryOffset` arbitrary - so a `&SYSTEM_PROCESS_INFORMATION`
+/// over the buffer would be misaligned often enough to matter.
 pub struct ProcessEntry<'a> {
     buf: &'a [u64],
-    /// The entry's leading `SYSTEM_PROCESS_INFORMATION`, borrowed from the
-    /// snapshot buffer. Aligned, so it is read directly rather than copied.
-    info: &'a SYSTEM_PROCESS_INFORMATION,
+    /// Unaligned copy of the entry's leading `SYSTEM_PROCESS_INFORMATION`.
+    header: SYSTEM_PROCESS_INFORMATION,
     /// Byte offset of this entry within `buf`.
     start: usize,
     /// Byte offset one past this entry: the bound for its variable-length data.
@@ -708,7 +708,7 @@ pub struct ProcessEntry<'a> {
 
 impl<'a> ProcessEntry<'a> {
     pub fn info(&self) -> &SYSTEM_PROCESS_INFORMATION {
-        self.info
+        &self.header
     }
 
     /// The `ImageName`, reduced to the file name when the snapshot supplied a
@@ -721,7 +721,7 @@ impl<'a> ProcessEntry<'a> {
     /// looks for a '.', so both classes are normalised to the short form -
     /// output must not change just because the caller happened to be elevated.
     pub fn image_name(&self) -> String {
-        let name = unicode_string_to_owned(&self.info.ImageName);
+        let name = unicode_string_to_owned(&self.header.ImageName);
         match self.kind {
             SnapshotKind::Basic => name,
             SnapshotKind::Full => match name.rsplit('\\').next() {
@@ -743,16 +743,19 @@ impl<'a> ProcessEntry<'a> {
     pub fn threads(&self) -> Vec<ThreadSnapshot> {
         let (base, stride, len) = self.threads_span();
         let mut ret = Vec::with_capacity(len);
-        let pid = self.info.UniqueProcessId as usize as i32;
+        let pid = self.header.UniqueProcessId as usize as i32;
 
         for index in 0..len {
             // SAFETY: `base + index * stride` is inside the entry (`index <
-            // len`) and 8-byte aligned, so a `&SYSTEM_THREAD_INFORMATION`
-            // over it is valid. Both record types start with that structure
-            // (see the `ThreadInfo` offset assertion), which is why the stride
-            // is the only thing that differs between the two classes.
-            let thread: &SYSTEM_THREAD_INFORMATION =
-                unsafe { &*base.add(index * stride).cast::<SYSTEM_THREAD_INFORMATION>() };
+            // len`). The record is copied because it can be misaligned. Both
+            // record types start with `SYSTEM_THREAD_INFORMATION` (see the
+            // `ThreadInfo` offset assertion), which is why the stride is the
+            // only thing that differs between the two classes.
+            let thread: SYSTEM_THREAD_INFORMATION = unsafe {
+                base.add(index * stride)
+                    .cast::<SYSTEM_THREAD_INFORMATION>()
+                    .read_unaligned()
+            };
 
             ret.push(ThreadSnapshot {
                 tid: thread.ClientId.UniqueThread as usize as i32,
@@ -761,7 +764,7 @@ impl<'a> ProcessEntry<'a> {
                 kernel_time: thread.KernelTime as u64,
                 user_time: thread.UserTime as u64,
                 priority: thread.Priority,
-                state: decode_state(thread),
+                state: decode_state(&thread),
             });
         }
 
@@ -782,14 +785,15 @@ impl<'a> ProcessEntry<'a> {
             .saturating_add(size_of::<SYSTEM_PROCESS_INFORMATION>());
 
         let available = self.end.saturating_sub(first);
-        let wanted = (self.info.NumberOfThreads as usize).saturating_mul(stride);
+        let wanted = (self.header.NumberOfThreads as usize).saturating_mul(stride);
         let len = wanted.min(available) / stride;
 
-        // `info` borrows the entry that starts at `start`, so this is
-        // `start + 256`: inside the buffer, and 8-byte aligned like every
-        // entry. Each stride is a multiple of 8, so every record is aligned
-        // too, and `len` was clamped so the last one stays inside the entry.
-        (self.info.Threads.as_ptr().cast::<u8>(), stride, len)
+        // SAFETY: `first` is `start + 256`, and `start + header <= limit` was
+        // checked by the iterator, so it is inside the buffer. `len` was
+        // clamped so the last record stays inside the entry too. The records
+        // are read unaligned, so no alignment guarantee is needed.
+        let base = unsafe { self.buf.as_ptr().cast::<u8>().add(first) };
+        (base, stride, len)
     }
 
     /// The scheduler state of the most active thread of this entry.
@@ -807,13 +811,13 @@ impl<'a> ProcessEntry<'a> {
 
         for index in 0..len {
             // SAFETY: `base + index * stride` is inside the entry (`index <
-            // len`) and 8-byte aligned, so a `&SYSTEM_THREAD_INFORMATION`
-            // over it is valid. Both record types start with that structure
-            // (see the `ThreadInfo` offset assertion), which is why the stride
-            // is the only thing that differs between the two classes.
-            let thread: &SYSTEM_THREAD_INFORMATION =
-                unsafe { &*base.add(index * stride).cast::<SYSTEM_THREAD_INFORMATION>() };
-            let state = decode_state(thread);
+            // len`). The record is copied because it can be misaligned.
+            let thread: SYSTEM_THREAD_INFORMATION = unsafe {
+                base.add(index * stride)
+                    .cast::<SYSTEM_THREAD_INFORMATION>()
+                    .read_unaligned()
+            };
+            let state = decode_state(&thread);
             let rank = activity(state);
             if rank < best_rank {
                 best_rank = rank;
@@ -841,7 +845,7 @@ impl<'a> ProcessEntry<'a> {
         let base = self
             .start
             .checked_add(header)?
-            .checked_add((self.info.NumberOfThreads as usize).checked_mul(stride)?)?;
+            .checked_add((self.header.NumberOfThreads as usize).checked_mul(stride)?)?;
 
         // The fixed prefix we read must fit inside the entry; the variable
         // length data trailing it is reached only through the offsets.
@@ -855,16 +859,15 @@ impl<'a> ProcessEntry<'a> {
     pub fn user_sid(&self) -> Option<SID_MAX> {
         let base = self.extension_base()?;
 
-        // SAFETY: `extension_base` already verified `base + prefix <= end`, and
-        // `base` is a multiple of 8 (`start` + header + N*stride), so the
-        // extension is aligned; borrow it instead of copying it out.
-        let fields: &SYSTEM_PROCESS_INFORMATION_EXTENSION = unsafe {
-            &*self
-                .buf
+        // SAFETY: `extension_base` already verified `base + prefix <= end`.
+        // The extension is copied because it can be misaligned.
+        let fields: SYSTEM_PROCESS_INFORMATION_EXTENSION = unsafe {
+            self.buf
                 .as_ptr()
                 .cast::<u8>()
                 .add(base)
                 .cast::<SYSTEM_PROCESS_INFORMATION_EXTENSION>()
+                .read_unaligned()
         };
 
         if fields.UserSidOffset == 0 {
@@ -886,15 +889,14 @@ impl<'a> ProcessEntry<'a> {
     pub fn classification(&self) -> Option<u32> {
         let base = self.extension_base()?;
         // `Flags` sits at offset 48 within the extension; `Classification` is
-        // its bits 1..=4. `base` is 8-aligned, so a `u32` read at `base + 48`
-        // is aligned.
+        // its bits 1..=4. Read unaligned: the extension can be misaligned.
         let flags: u32 = unsafe {
             self.buf
                 .as_ptr()
                 .cast::<u8>()
                 .add(base + offset_of!(SYSTEM_PROCESS_INFORMATION_EXTENSION, Flags))
                 .cast::<u32>()
-                .read()
+                .read_unaligned()
         };
         Some((flags >> 1) & 0xF)
     }
@@ -977,23 +979,23 @@ impl<'a> Iterator for ProcessIter<'a> {
             return None;
         }
 
-        // SAFETY: the buffer is a `Vec<u64>`, so it is 8-byte aligned, and the
-        // kernel lays each entry on an 8-byte boundary (`NextEntryOffset` is a
-        // multiple of 8). `offset + size_of <= limit`, so the header is fully
-        // inside the buffer and aligned; borrow it directly instead of copying.
-        debug_assert_eq!(offset % 8, 0);
-        let info: &SYSTEM_PROCESS_INFORMATION = unsafe {
-            &*self
-                .snapshot
+        // SAFETY: `offset + size_of <= limit`, so the header lies wholly inside
+        // the buffer. Copied rather than borrowed: entries of a full snapshot
+        // are not guaranteed to be 8-byte aligned.
+        let info: SYSTEM_PROCESS_INFORMATION = unsafe {
+            self.snapshot
                 .words
                 .as_ptr()
                 .cast::<u8>()
                 .add(offset)
                 .cast::<SYSTEM_PROCESS_INFORMATION>()
+                .read_unaligned()
         };
 
         // `NextEntryOffset == 0` marks the last entry. An offset that would not
         // move past this header is malformed - stop rather than loop forever.
+        // Alignment is deliberately not required: a full snapshot pads entries
+        // to 2 bytes, so demanding 8 would silently truncate the process list.
         let next = info.NextEntryOffset as usize;
         let end = if next == 0 || next < header {
             limit
@@ -1004,7 +1006,7 @@ impl<'a> Iterator for ProcessIter<'a> {
 
         Some(ProcessEntry {
             buf: &self.snapshot.words,
-            info,
+            header: info,
             start: offset,
             end,
             kind: self.snapshot.kind,

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -172,6 +172,49 @@ const _: () =
     assert!(offset_of!(SYSTEM_PROCESS_INFORMATION_EXTENSION, PackageFullNameOffset) == 56);
 const _: () = assert!(size_of::<SYSTEM_PROCESS_INFORMATION_EXTENSION>() == 64);
 
+/// `SECTION_IMAGE_INFORMATION` - the output of `ProcessImageInformation` (37).
+///
+/// `Machine` is the `IMAGE_FILE_MACHINE_*` of the executable image, so it
+/// reports the architecture of the process itself: a 32-bit process on a
+/// 64-bit host still reports `IMAGE_FILE_MACHINE_I386`.
+///
+/// The header declares `SubSystemVersion` and `OperatingSystemVersion` as
+/// unions of two `USHORT`s and `ImageFlags` as a union of bit fields; they are
+/// spelled out as their members here, which leaves the layout untouched.
+#[repr(C)]
+#[allow(non_snake_case)]
+#[allow(dead_code)]
+pub struct SECTION_IMAGE_INFORMATION {
+    pub TransferAddress: *mut c_void,
+    pub ZeroBits: u32,
+    /// `SIZE_T` in the header, which is why the next field is padded to an
+    /// 8-byte boundary and the structure ends up 64 bytes wide.
+    pub MaximumStackSize: usize,
+    pub CommittedStackSize: usize,
+    pub SubSystemType: u32,
+    pub SubSystemMinorVersion: u16,
+    pub SubSystemMajorVersion: u16,
+    pub MajorOperatingSystemVersion: u16,
+    pub MinorOperatingSystemVersion: u16,
+    pub ImageCharacteristics: u16,
+    pub DllCharacteristics: u16,
+    pub Machine: u16,
+    pub ImageContainsCode: u8,
+    pub ImageFlags: u8,
+    pub LoaderFlags: u32,
+    pub ImageFileSize: u32,
+    pub CheckSum: u32,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(size_of::<SECTION_IMAGE_INFORMATION>() == 64);
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(offset_of!(SECTION_IMAGE_INFORMATION, Machine) == 48);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(size_of::<SECTION_IMAGE_INFORMATION>() == 48);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(offset_of!(SECTION_IMAGE_INFORMATION, Machine) == 32);
+
 /// Fixed part of a `SID`: revision, sub-authority count and the 6-byte
 /// identifier authority. `windows-sys` types the trailing sub-authorities as
 /// `[u32; 1]`, so `size_of::<SID>()` is 4 bytes more than this.
@@ -337,6 +380,8 @@ pub const SYSTEM_PROCESS_INFORMATION_CLASS: u32 = 5;
 pub const SYSTEM_FULL_PROCESS_INFORMATION_CLASS: u32 = 148;
 /// ProcessInformationClass. Windows 8.1 and newer
 pub const PROCESS_COMMAND_LINE_INFORMATION_CLASS: u32 = 60;
+/// ProcessInformationClass. Vista and newer
+pub const PROCESS_IMAGE_INFORMATION_CLASS: u32 = 37;
 /// NTSTATUS
 pub const STATUS_SUCCESS: i32 = 0;
 pub const STATUS_INFO_LENGTH_MISMATCH: i32 = 0xC000_0004u32 as i32;
@@ -896,6 +941,39 @@ pub fn process_command_line(handle: HANDLE) -> Option<String> {
     )
 }
 
+/// Reads the `IMAGE_FILE_MACHINE_*` of the executable image of `handle`.
+///
+/// `ProcessImageInformation` only needs `PROCESS_QUERY_LIMITED_INFORMATION`,
+/// so it also answers for protected processes that refuse the full query
+/// rights. Anything older than Vista yields `None`.
+pub fn process_image_machine(handle: HANDLE) -> Option<u16> {
+    let query = nt_query_information_process()?;
+
+    // SAFETY: a zeroed `SECTION_IMAGE_INFORMATION` is a valid output buffer -
+    // every field is an integer or a pointer, and only `Machine` is read.
+    let mut info: SECTION_IMAGE_INFORMATION = unsafe { std::mem::zeroed() };
+    let mut ret_len: u32 = 0;
+
+    let status = unsafe {
+        query(
+            handle,
+            PROCESS_IMAGE_INFORMATION_CLASS,
+            ptr::addr_of_mut!(info).cast::<c_void>(),
+            size_of::<SECTION_IMAGE_INFORMATION>() as u32,
+            ptr::addr_of_mut!(ret_len),
+        )
+    };
+    if status != STATUS_SUCCESS {
+        return None;
+    }
+    // Short writes leave `Machine` unset.
+    if (ret_len as usize) < offset_of!(SECTION_IMAGE_INFORMATION, Machine) + size_of::<u16>() {
+        return None;
+    }
+
+    Some(info.Machine)
+}
+
 /// Copies the characters of `string` out of `buffer`, which must still be
 /// alive (the `Buffer` pointer of an `ImageName` points inside it).
 pub fn unicode_string_to_owned(string: &UNICODE_STRING) -> String {
@@ -1084,5 +1162,25 @@ mod tests {
             kind: SnapshotKind::Basic,
         };
         assert_eq!(snap.iter().next().unwrap().classification(), None);
+    }
+
+    /// `IMAGE_FILE_MACHINE_*` of the architecture this test was built for.
+    #[cfg(target_arch = "x86_64")]
+    const OWN_MACHINE: u16 = 0x8664;
+    #[cfg(target_arch = "x86")]
+    const OWN_MACHINE: u16 = 0x014c;
+    #[cfg(target_arch = "aarch64")]
+    const OWN_MACHINE: u16 = 0xaa64;
+
+    /// Queries a real process, so it also pins down the buffer size the
+    /// kernel insists on: a wrong `SECTION_IMAGE_INFORMATION` layout answers
+    /// `STATUS_INFO_LENGTH_MISMATCH` and the query returns `None`.
+    #[test]
+    fn image_machine_of_this_process() {
+        use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+        // SAFETY: the pseudo-handle needs no closing.
+        let handle = unsafe { GetCurrentProcess() };
+        assert_eq!(process_image_machine(handle), Some(OWN_MACHINE));
     }
 }

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -226,6 +226,95 @@ const _: () = assert!(size_of::<SECTION_IMAGE_INFORMATION>() == 48);
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(offset_of!(SECTION_IMAGE_INFORMATION, Machine) == 32);
 
+/// `PROCESS_BASIC_INFORMATION` - the output of `ProcessBasicInformation` (0).
+///
+/// `PebBaseAddress` is the address of the process's PEB in the target's
+/// address space; it is only meaningful to `ReadProcessMemory`.
+///
+/// `windows-sys` gates its own copy behind `Win32_System_Kernel`, so it is
+/// spelled out here like the rest of the NT surface this crate needs.
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct PROCESS_BASIC_INFORMATION {
+    pub ExitStatus: i32,
+    pub PebBaseAddress: *mut c_void,
+    pub AffinityMask: usize,
+    pub BasePriority: i32,
+    pub UniqueProcessId: HANDLE,
+    pub InheritedFromUniqueProcessId: HANDLE,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(size_of::<PROCESS_BASIC_INFORMATION>() == 48);
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(offset_of!(PROCESS_BASIC_INFORMATION, PebBaseAddress) == 8);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(size_of::<PROCESS_BASIC_INFORMATION>() == 24);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(offset_of!(PROCESS_BASIC_INFORMATION, PebBaseAddress) == 4);
+
+/// The leading, version-stable part of `PEB`, up to and including
+/// `ProcessParameters`.
+///
+/// Everything after `ProcessParameters` has grown and been reordered across
+/// Windows versions, but the prefix has stayed put since XP, which is all the
+/// working-directory read needs.
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct PEB_PREFIX {
+    pub InheritedAddressSpace: u8,
+    pub ReadImageFileExecOptions: u8,
+    pub BeingDebugged: u8,
+    pub BitField: u8,
+    pub Mutant: HANDLE,
+    pub ImageBaseAddress: *mut c_void,
+    pub Ldr: *mut c_void,
+    pub ProcessParameters: *mut c_void,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(offset_of!(PEB_PREFIX, ProcessParameters) == 0x20);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(offset_of!(PEB_PREFIX, ProcessParameters) == 0x10);
+
+/// `CURDIR` - the current-directory record of
+/// `RTL_USER_PROCESS_PARAMETERS`.
+#[repr(C)]
+#[allow(non_snake_case)]
+#[allow(clippy::upper_case_acronyms)]
+pub struct CURDIR {
+    pub DosPath: UNICODE_STRING,
+    pub Handle: HANDLE,
+}
+
+/// The leading, version-stable part of `RTL_USER_PROCESS_PARAMETERS`, up to
+/// and including `CurrentDirectory`.
+///
+/// The fields after `CurrentDirectory` (`DllPath`, `ImagePathName`,
+/// `CommandLine`, ...) are not needed here; the prefix layout has been stable
+/// since XP.
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct RTL_USER_PROCESS_PARAMETERS_PREFIX {
+    pub MaximumLength: u32,
+    pub Length: u32,
+    pub Flags: u32,
+    pub DebugFlags: u32,
+    pub ConsoleHandle: HANDLE,
+    pub ConsoleFlags: u32,
+    pub StandardInput: HANDLE,
+    pub StandardOutput: HANDLE,
+    pub StandardError: HANDLE,
+    pub CurrentDirectory: CURDIR,
+}
+
+#[cfg(target_pointer_width = "64")]
+const _: () =
+    assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, CurrentDirectory) == 0x38);
+#[cfg(target_pointer_width = "32")]
+const _: () =
+    assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, CurrentDirectory) == 0x24);
+
 /// Fixed part of a `SID`: revision, sub-authority count and the 6-byte
 /// identifier authority. `windows-sys` types the trailing sub-authorities as
 /// `[u32; 1]`, so `size_of::<SID>()` is 4 bytes more than this.
@@ -394,6 +483,8 @@ pub const SYSTEM_FULL_PROCESS_INFORMATION_CLASS: u32 = 148;
 pub const PROCESS_COMMAND_LINE_INFORMATION_CLASS: u32 = 60;
 /// ProcessInformationClass. Vista and newer
 pub const PROCESS_IMAGE_INFORMATION_CLASS: u32 = 37;
+/// ProcessInformationClass. Always available
+pub const PROCESS_BASIC_INFORMATION_CLASS: u32 = 0;
 /// NTSTATUS
 pub const STATUS_SUCCESS: i32 = 0;
 pub const STATUS_INFO_LENGTH_MISMATCH: i32 = 0xC000_0004u32 as i32;
@@ -1092,6 +1183,40 @@ pub fn process_image_machine(handle: HANDLE) -> Option<u16> {
     }
 
     Some(info.Machine)
+}
+
+/// Reads the PEB base address of `handle`.
+///
+/// `ProcessBasicInformation` only needs `PROCESS_QUERY_LIMITED_INFORMATION`.
+/// The returned address lives in the target process's address space and is
+/// only meaningful to `ReadProcessMemory`.
+pub fn process_peb_address(handle: HANDLE) -> Option<usize> {
+    let query = nt_query_information_process()?;
+
+    // SAFETY: a zeroed `PROCESS_BASIC_INFORMATION` is a valid output buffer -
+    // every field is an integer or a pointer, and only `PebBaseAddress` is read.
+    let mut info: PROCESS_BASIC_INFORMATION = unsafe { std::mem::zeroed() };
+    let mut ret_len: u32 = 0;
+
+    let status = unsafe {
+        query(
+            handle,
+            PROCESS_BASIC_INFORMATION_CLASS,
+            ptr::addr_of_mut!(info).cast::<c_void>(),
+            size_of::<PROCESS_BASIC_INFORMATION>() as u32,
+            ptr::addr_of_mut!(ret_len),
+        )
+    };
+    if status != STATUS_SUCCESS {
+        return None;
+    }
+    // Short writes leave `PebBaseAddress` unset.
+    if (ret_len as usize) < offset_of!(PROCESS_BASIC_INFORMATION, PebBaseAddress) + size_of::<usize>()
+    {
+        return None;
+    }
+
+    Some(info.PebBaseAddress as usize)
 }
 
 /// Copies the characters of `string` out of `buffer`, which must still be

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -123,6 +123,24 @@ pub struct PROCESS_DISK_COUNTERS {
     pub FlushOperationCount: u64,
 }
 
+/// `PROCESS_NETWORK_COUNTERS` - the output of `ProcessNetworkIoInformation`
+/// (114).
+///
+/// Both counters are cumulative for the lifetime of the process, so a rate
+/// needs two samples taken an interval apart.
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct PROCESS_NETWORK_COUNTERS {
+    /// Total bytes received by the process.
+    pub BytesIn: u64,
+    /// Total bytes sent by the process.
+    pub BytesOut: u64,
+}
+
+const _: () = assert!(size_of::<PROCESS_NETWORK_COUNTERS>() == 16);
+const _: () = assert!(offset_of!(PROCESS_NETWORK_COUNTERS, BytesIn) == 0);
+const _: () = assert!(offset_of!(PROCESS_NETWORK_COUNTERS, BytesOut) == 8);
+
 /// The leading, version-stable part of `SYSTEM_PROCESS_INFORMATION_EXTENSION`,
 /// as returned by `SystemFullProcessInformation` (148).
 ///
@@ -462,6 +480,9 @@ impl std::hash::Hash for SID_MAX {
 /// elevated: without it the query returns `STATUS_ACCESS_DENIED`. Carries
 /// the process extension, which includes the user SID.
 pub const SYSTEM_FULL_PROCESS_INFORMATION_CLASS: i32 = 148;
+
+// ProcessInformationClass. Windows 11
+pub const PROCESS_NETWORK_IO_COUNTERS_CLASS: i32 = 114;
 
 /// Guard against a nonsensical `UNICODE_STRING::Length` turning into a huge
 /// allocation. Real command lines are capped well below this.
@@ -1092,6 +1113,61 @@ pub fn process_image_machine(handle: HANDLE) -> Option<u16> {
     Some(info.Machine)
 }
 
+// ---------------------------------------------------------------------------
+// ProcessNetworkIoInformation
+// ---------------------------------------------------------------------------
+
+/// What one `ProcessNetworkIoInformation` query produced: the status, how much
+/// the kernel wrote, and the counters themselves.
+///
+/// The status is handed back rather than swallowed so a caller can tell the
+/// two failures apart: "this Windows does not implement the class" leaves the
+/// columns at zero, while `STATUS_INFO_LENGTH_MISMATCH` would mean this
+/// structure is the wrong size.
+struct NetworkCountersQuery {
+    status: i32,
+    written: u32,
+    counters: PROCESS_NETWORK_COUNTERS,
+}
+
+fn query_network_counters(handle: HANDLE) -> NetworkCountersQuery {
+    // SAFETY: a zeroed `PROCESS_NETWORK_COUNTERS` is a valid output buffer -
+    // both fields are integers.
+    let mut info: PROCESS_NETWORK_COUNTERS = unsafe { std::mem::zeroed() };
+    let mut ret_len: u32 = 0;
+
+    let status = unsafe {
+        NtQueryInformationProcess(
+            handle,
+            PROCESS_NETWORK_IO_COUNTERS_CLASS,
+            ptr::addr_of_mut!(info).cast::<c_void>(),
+            size_of::<PROCESS_NETWORK_COUNTERS>() as u32,
+            ptr::addr_of_mut!(ret_len),
+        )
+    };
+
+    NetworkCountersQuery {
+        status,
+        written: ret_len,
+        counters: info,
+    }
+}
+
+/// Reads the cumulative network traffic of `handle`.
+///
+/// `None` when the class is not implemented - it is a Windows 11 addition, so
+/// an older build answers `STATUS_INVALID_INFO_CLASS` - when the handle lacks
+/// the rights, or when the kernel wrote less than the whole structure.
+pub fn process_network_counters(handle: HANDLE) -> Option<PROCESS_NETWORK_COUNTERS> {
+    let query = query_network_counters(handle);
+    if query.status != STATUS_SUCCESS
+        || (query.written as usize) < size_of::<PROCESS_NETWORK_COUNTERS>()
+    {
+        return None;
+    }
+    Some(query.counters)
+}
+
 /// Reads the PEB base address of `handle`.
 ///
 /// `ProcessBasicInformation` only needs `PROCESS_QUERY_LIMITED_INFORMATION`.
@@ -1603,5 +1679,29 @@ mod tests {
         // SAFETY: the pseudo-handle needs no closing.
         let handle = unsafe { GetCurrentProcess() };
         assert_eq!(process_image_machine(handle), Some(OWN_MACHINE));
+    }
+
+    /// `ProcessNetworkIoInformation` is a Windows 11 addition, so whether the
+    /// counters come back at all depends on the build. What has to hold on
+    /// every build is that the 16-byte structure is accepted: a wrong
+    /// `PROCESS_NETWORK_COUNTERS` layout is answered with
+    /// `STATUS_INFO_LENGTH_MISMATCH`, which would leave both network columns
+    /// empty without a word of explanation.
+    #[test]
+    fn network_counters_layout_is_accepted() {
+        use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+        // SAFETY: the pseudo-handle needs no closing.
+        let handle = unsafe { GetCurrentProcess() };
+        let query = query_network_counters(handle);
+
+        assert_ne!(query.status, STATUS_INFO_LENGTH_MISMATCH);
+        if query.status == STATUS_SUCCESS {
+            assert_eq!(
+                query.written as usize,
+                size_of::<PROCESS_NETWORK_COUNTERS>()
+            );
+            assert!(process_network_counters(handle).is_some());
+        }
     }
 }

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -10,49 +10,24 @@ use std::fmt::Write;
 use std::mem::{offset_of, size_of};
 use std::ptr;
 use std::slice;
-use std::sync::OnceLock;
 
-use windows_sys::Win32::Foundation::{HANDLE, HMODULE};
+use windows_sys::Wdk::System::SystemInformation::{
+    NtQuerySystemInformation, SystemProcessInformation,
+};
+use windows_sys::Wdk::System::SystemServices::VM_COUNTERS;
+use windows_sys::Wdk::System::Threading::{
+    NtQueryInformationProcess, ProcessBasicInformation, ProcessCommandLineInformation,
+    ProcessImageInformation,
+};
+use windows_sys::Win32::Foundation::UNICODE_STRING;
+use windows_sys::Win32::Foundation::{HANDLE, STATUS_INFO_LENGTH_MISMATCH, STATUS_SUCCESS};
 use windows_sys::Win32::Security::{PSID, SECURITY_MAX_SID_SIZE, SID};
-use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleW, GetProcAddress};
-use windows_sys::Win32::System::Threading::IO_COUNTERS;
+use windows_sys::Win32::System::Threading::{IO_COUNTERS, PROCESS_BASIC_INFORMATION};
+use windows_sys::Win32::System::WindowsProgramming::CLIENT_ID;
 
 // ---------------------------------------------------------------------------
 // Structures
 // ---------------------------------------------------------------------------
-
-#[repr(C)]
-#[allow(non_snake_case)]
-#[derive(Copy, Clone)]
-pub struct UNICODE_STRING {
-    /// Byte length of `Buffer`, excluding any terminating NUL.
-    pub Length: u16,
-    pub MaximumLength: u16,
-    pub Buffer: *mut u16,
-}
-
-#[repr(C)]
-#[allow(non_snake_case)]
-pub struct VM_COUNTERS {
-    pub PeakVirtualSize: usize,
-    pub VirtualSize: usize,
-    pub PageFaultCount: u32,
-    pub PeakWorkingSetSize: usize,
-    pub WorkingSetSize: usize,
-    pub QuotaPeakPagedPoolUsage: usize,
-    pub QuotaPagedPoolUsage: usize,
-    pub QuotaPeakNonPagedPoolUsage: usize,
-    pub QuotaNonPagedPoolUsage: usize,
-    pub PagefileUsage: usize,
-    pub PeakPagefileUsage: usize,
-}
-
-#[repr(C)]
-#[allow(non_snake_case)]
-pub struct CLIENT_ID {
-    pub UniqueProcess: HANDLE,
-    pub UniqueThread: HANDLE,
-}
 
 /// `SYSTEM_THREAD_INFORMATION` - the thread record of
 /// `SystemProcessInformation` (5).
@@ -226,33 +201,6 @@ const _: () = assert!(size_of::<SECTION_IMAGE_INFORMATION>() == 48);
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(offset_of!(SECTION_IMAGE_INFORMATION, Machine) == 32);
 
-/// `PROCESS_BASIC_INFORMATION` - the output of `ProcessBasicInformation` (0).
-///
-/// `PebBaseAddress` is the address of the process's PEB in the target's
-/// address space; it is only meaningful to `ReadProcessMemory`.
-///
-/// `windows-sys` gates its own copy behind `Win32_System_Kernel`, so it is
-/// spelled out here like the rest of the NT surface this crate needs.
-#[repr(C)]
-#[allow(non_snake_case)]
-pub struct PROCESS_BASIC_INFORMATION {
-    pub ExitStatus: i32,
-    pub PebBaseAddress: *mut c_void,
-    pub AffinityMask: usize,
-    pub BasePriority: i32,
-    pub UniqueProcessId: HANDLE,
-    pub InheritedFromUniqueProcessId: HANDLE,
-}
-
-#[cfg(target_pointer_width = "64")]
-const _: () = assert!(size_of::<PROCESS_BASIC_INFORMATION>() == 48);
-#[cfg(target_pointer_width = "64")]
-const _: () = assert!(offset_of!(PROCESS_BASIC_INFORMATION, PebBaseAddress) == 8);
-#[cfg(target_pointer_width = "32")]
-const _: () = assert!(size_of::<PROCESS_BASIC_INFORMATION>() == 24);
-#[cfg(target_pointer_width = "32")]
-const _: () = assert!(offset_of!(PROCESS_BASIC_INFORMATION, PebBaseAddress) == 4);
-
 /// The leading, version-stable part of `PEB`, up to and including
 /// `ProcessParameters`.
 ///
@@ -309,11 +257,9 @@ pub struct RTL_USER_PROCESS_PARAMETERS_PREFIX {
 }
 
 #[cfg(target_pointer_width = "64")]
-const _: () =
-    assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, CurrentDirectory) == 0x38);
+const _: () = assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, CurrentDirectory) == 0x38);
 #[cfg(target_pointer_width = "32")]
-const _: () =
-    assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, CurrentDirectory) == 0x24);
+const _: () = assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, CurrentDirectory) == 0x24);
 
 /// Fixed part of a `SID`: revision, sub-authority count and the 6-byte
 /// identifier authority. `windows-sys` types the trailing sub-authorities as
@@ -472,88 +418,14 @@ impl std::hash::Hash for SID_MAX {
 // Constants
 // ---------------------------------------------------------------------------
 
-/// SystemInformationClass. Always available; its thread records are
-/// `SYSTEM_THREAD_INFORMATION` (80 bytes).
-pub const SYSTEM_PROCESS_INFORMATION_CLASS: u32 = 5;
 /// SystemInformationClass. Windows 8.1 and newer, and the caller has to be
 /// elevated: without it the query returns `STATUS_ACCESS_DENIED`. Carries
 /// the process extension, which includes the user SID.
-pub const SYSTEM_FULL_PROCESS_INFORMATION_CLASS: u32 = 148;
-/// ProcessInformationClass. Windows 8.1 and newer
-pub const PROCESS_COMMAND_LINE_INFORMATION_CLASS: u32 = 60;
-/// ProcessInformationClass. Vista and newer
-pub const PROCESS_IMAGE_INFORMATION_CLASS: u32 = 37;
-/// ProcessInformationClass. Always available
-pub const PROCESS_BASIC_INFORMATION_CLASS: u32 = 0;
-/// NTSTATUS
-pub const STATUS_SUCCESS: i32 = 0;
-pub const STATUS_INFO_LENGTH_MISMATCH: i32 = 0xC000_0004u32 as i32;
+pub const SYSTEM_FULL_PROCESS_INFORMATION_CLASS: i32 = 148;
 
 /// Guard against a nonsensical `UNICODE_STRING::Length` turning into a huge
 /// allocation. Real command lines are capped well below this.
 const MAX_COMMAND_LINE_BYTES: usize = 64 * 1024;
-
-// ---------------------------------------------------------------------------
-// Function resolution
-// ---------------------------------------------------------------------------
-
-#[allow(non_snake_case)]
-type NtQuerySystemInformationFn = unsafe extern "system" fn(
-    SystemInformationClass: u32,
-    SystemInformation: *mut c_void,
-    SystemInformationLength: u32,
-    ReturnLength: *mut u32,
-) -> i32;
-
-#[allow(non_snake_case)]
-type NtQueryInformationProcessFn = unsafe extern "system" fn(
-    ProcessHandle: HANDLE,
-    ProcessInformationClass: u32,
-    ProcessInformation: *mut c_void,
-    ProcessInformationLength: u32,
-    ReturnLength: *mut u32,
-) -> i32;
-
-static NT_QUERY_SYSTEM_INFORMATION: OnceLock<Option<NtQuerySystemInformationFn>> = OnceLock::new();
-static NT_QUERY_INFORMATION_PROCESS: OnceLock<Option<NtQueryInformationProcessFn>> =
-    OnceLock::new();
-
-/// `ntdll.dll` is mapped into every user process, so a handle lookup is enough
-/// and there is nothing to release. Stored as `usize` because a bare
-/// `HMODULE` (a raw pointer) is not `Sync` and cannot live in a `static`.
-fn ntdll() -> HMODULE {
-    static HANDLE: OnceLock<usize> = OnceLock::new();
-    let addr = *HANDLE.get_or_init(|| {
-        let name: Vec<u16> = "ntdll.dll\0".encode_utf16().collect();
-        unsafe { GetModuleHandleW(name.as_ptr()) as usize }
-    });
-    addr as HMODULE
-}
-
-fn ntdll_proc(name: &[u8]) -> Option<unsafe extern "system" fn() -> isize> {
-    let module = ntdll();
-    if module.is_null() {
-        return None;
-    }
-    // SAFETY: `name` is NUL terminated and outlives the call.
-    unsafe { GetProcAddress(module, name.as_ptr()) }
-}
-
-pub fn nt_query_system_information() -> Option<NtQuerySystemInformationFn> {
-    *NT_QUERY_SYSTEM_INFORMATION.get_or_init(|| {
-        ntdll_proc(b"NtQuerySystemInformation\0")
-            // SAFETY: both are `extern "system"` fn pointers; the ABI matches.
-            .map(|f| unsafe { std::mem::transmute::<_, NtQuerySystemInformationFn>(f) })
-    })
-}
-
-pub fn nt_query_information_process() -> Option<NtQueryInformationProcessFn> {
-    *NT_QUERY_INFORMATION_PROCESS.get_or_init(|| {
-        ntdll_proc(b"NtQueryInformationProcess\0")
-            // SAFETY: both are `extern "system"` fn pointers; the ABI matches.
-            .map(|f| unsafe { std::mem::transmute::<_, NtQueryInformationProcessFn>(f) })
-    })
-}
 
 // ---------------------------------------------------------------------------
 // SystemProcessInformation
@@ -623,15 +495,14 @@ pub fn query_system_processes() -> Option<SystemProcessSnapshot> {
         });
     }
 
-    let words = query_system_info_class(SYSTEM_PROCESS_INFORMATION_CLASS)?;
+    let words = query_system_info_class(SystemProcessInformation)?;
     Some(SystemProcessSnapshot {
         words,
         kind: SnapshotKind::Basic,
     })
 }
 
-fn query_system_info_class(class: u32) -> Option<Vec<u64>> {
-    let query = nt_query_system_information()?;
+fn query_system_info_class(class: i32) -> Option<Vec<u64>> {
     let mut words = vec![0u64; 0];
     // A `Vec<u64>` is allocated 8-byte aligned, which is what the
     // `SYSTEM_PROCESS_INFORMATION` structures in the snapshot require.
@@ -641,7 +512,7 @@ fn query_system_info_class(class: u32) -> Option<Vec<u64>> {
         let mut ret_len: u32 = 0;
         let len = words.len() * size_of::<u64>();
         let status = unsafe {
-            query(
+            NtQuerySystemInformation(
                 class,
                 words.as_mut_ptr().cast::<c_void>(),
                 len as u32,
@@ -1094,8 +965,6 @@ impl<'a> Iterator for ProcessIter<'a> {
 /// Needs `PROCESS_QUERY_LIMITED_INFORMATION` and Windows 8.1 or newer.
 /// Anything else yields `None`.
 pub fn process_command_line(handle: HANDLE) -> Option<String> {
-    let query = nt_query_information_process()?;
-
     // Room for the header plus a typical command line.
     let mut buf = vec![0u64; (size_of::<UNICODE_STRING>() + 1024).div_ceil(size_of::<u64>())];
     let mut status = STATUS_INFO_LENGTH_MISMATCH;
@@ -1103,9 +972,9 @@ pub fn process_command_line(handle: HANDLE) -> Option<String> {
     for _ in 0..4 {
         let mut ret_len: u32 = 0;
         status = unsafe {
-            query(
+            NtQueryInformationProcess(
                 handle,
-                PROCESS_COMMAND_LINE_INFORMATION_CLASS,
+                ProcessCommandLineInformation,
                 buf.as_mut_ptr().cast::<c_void>(),
                 (buf.len() * size_of::<u64>()) as u32,
                 ptr::addr_of_mut!(ret_len),
@@ -1158,17 +1027,15 @@ pub fn process_command_line(handle: HANDLE) -> Option<String> {
 /// so it also answers for protected processes that refuse the full query
 /// rights. Anything older than Vista yields `None`.
 pub fn process_image_machine(handle: HANDLE) -> Option<u16> {
-    let query = nt_query_information_process()?;
-
     // SAFETY: a zeroed `SECTION_IMAGE_INFORMATION` is a valid output buffer -
     // every field is an integer or a pointer, and only `Machine` is read.
     let mut info: SECTION_IMAGE_INFORMATION = unsafe { std::mem::zeroed() };
     let mut ret_len: u32 = 0;
 
     let status = unsafe {
-        query(
+        NtQueryInformationProcess(
             handle,
-            PROCESS_IMAGE_INFORMATION_CLASS,
+            ProcessImageInformation,
             ptr::addr_of_mut!(info).cast::<c_void>(),
             size_of::<SECTION_IMAGE_INFORMATION>() as u32,
             ptr::addr_of_mut!(ret_len),
@@ -1191,17 +1058,15 @@ pub fn process_image_machine(handle: HANDLE) -> Option<u16> {
 /// The returned address lives in the target process's address space and is
 /// only meaningful to `ReadProcessMemory`.
 pub fn process_peb_address(handle: HANDLE) -> Option<usize> {
-    let query = nt_query_information_process()?;
-
     // SAFETY: a zeroed `PROCESS_BASIC_INFORMATION` is a valid output buffer -
     // every field is an integer or a pointer, and only `PebBaseAddress` is read.
     let mut info: PROCESS_BASIC_INFORMATION = unsafe { std::mem::zeroed() };
     let mut ret_len: u32 = 0;
 
     let status = unsafe {
-        query(
+        NtQueryInformationProcess(
             handle,
-            PROCESS_BASIC_INFORMATION_CLASS,
+            ProcessBasicInformation,
             ptr::addr_of_mut!(info).cast::<c_void>(),
             size_of::<PROCESS_BASIC_INFORMATION>() as u32,
             ptr::addr_of_mut!(ret_len),
@@ -1211,7 +1076,8 @@ pub fn process_peb_address(handle: HANDLE) -> Option<usize> {
         return None;
     }
     // Short writes leave `PebBaseAddress` unset.
-    if (ret_len as usize) < offset_of!(PROCESS_BASIC_INFORMATION, PebBaseAddress) + size_of::<usize>()
+    if (ret_len as usize)
+        < offset_of!(PROCESS_BASIC_INFORMATION, PebBaseAddress) + size_of::<usize>()
     {
         return None;
     }

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -7,7 +7,6 @@
 
 use std::ffi::c_void;
 use std::fmt::Write;
-use std::marker::PhantomData;
 use std::mem::{offset_of, size_of};
 use std::ptr;
 use std::slice;
@@ -55,9 +54,15 @@ pub struct CLIENT_ID {
     pub UniqueThread: HANDLE,
 }
 
+/// `SYSTEM_THREAD_INFORMATION` - the thread record of
+/// `SystemProcessInformation` (5).
+///
+/// `SystemFullProcessInformation` (148) returns
+/// `SYSTEM_EXTENDED_THREAD_INFORMATION` instead, which begins with this
+/// structure and appends the extended pointers.
 #[repr(C)]
 #[allow(non_snake_case)]
-pub struct SYSTEM_THREADS {
+pub struct SYSTEM_THREAD_INFORMATION {
     pub KernelTime: i64,
     pub UserTime: i64,
     pub CreateTime: i64,
@@ -93,22 +98,27 @@ pub struct SYSTEM_PROCESS_INFORMATION {
     pub VirtualMemoryCounters: VM_COUNTERS,
     pub PrivatePageCount: usize,
     pub IoCounters: IO_COUNTERS,
-    /// C99-style flexible array member. The count is `NumberOfThreads`
-    pub Threads: [SYSTEM_THREADS; 0],
+    /// C99-style flexible array member. The count is `NumberOfThreads`. The
+    /// records are `SYSTEM_THREAD_INFORMATION` (80 bytes) for
+    /// `SystemProcessInformation` (5) and `SYSTEM_EXTENDED_THREAD_INFORMATION`
+    /// (136 bytes) for `SystemFullProcessInformation` (148).
+    pub Threads: [u64; 0],
     // String buffer for `ImageName`
 }
 
-/// `SYSTEM_EXTENDED_THREAD_INFORMATION` - the thread record used by
-/// `SystemExtendedProcessInformation` (57) and `SystemFullProcessInformation`
-/// (148) in place of `SYSTEM_THREADS`.
+/// `SYSTEM_EXTENDED_THREAD_INFORMATION` - the wider thread record returned by
+/// `SystemFullProcessInformation` (148) in place of
+/// `SYSTEM_THREAD_INFORMATION`.
 ///
-/// The leading union member is a plain `SYSTEM_THREADS`, which is the only
-/// part this crate reads; the trailing pointers are here so the array stride
-/// (used to locate the process extension) is the real one.
+/// Only the leading `SYSTEM_THREAD_INFORMATION` is read; the trailing pointers
+/// are declared so the array stride - which is what locates the process
+/// extension - keeps its real width.
 #[repr(C)]
 #[allow(non_snake_case)]
 pub struct SYSTEM_EXTENDED_THREAD_INFORMATION {
-    pub ThreadInfo: SYSTEM_THREADS,
+    pub ThreadInfo: SYSTEM_THREAD_INFORMATION,
+
+    // Extended
     pub StackBase: *mut c_void,
     pub StackLimit: *mut c_void,
     pub Win32StartAddress: *mut c_void,
@@ -122,9 +132,10 @@ pub struct SYSTEM_EXTENDED_THREAD_INFORMATION {
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(size_of::<SYSTEM_PROCESS_INFORMATION>() == 256);
 #[cfg(target_pointer_width = "64")]
-const _: () = assert!(size_of::<SYSTEM_THREADS>() == 80);
+const _: () = assert!(size_of::<SYSTEM_THREAD_INFORMATION>() == 80);
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(size_of::<SYSTEM_EXTENDED_THREAD_INFORMATION>() == 136);
+const _: () = assert!(offset_of!(SYSTEM_EXTENDED_THREAD_INFORMATION, ThreadInfo) == 0);
 
 /// `PROCESS_DISK_COUNTERS`
 #[repr(C)]
@@ -372,7 +383,8 @@ impl std::hash::Hash for SID_MAX {
 // Constants
 // ---------------------------------------------------------------------------
 
-/// SystemInformationClass
+/// SystemInformationClass. Always available; its thread records are
+/// `SYSTEM_THREAD_INFORMATION` (80 bytes).
 pub const SYSTEM_PROCESS_INFORMATION_CLASS: u32 = 5;
 /// SystemInformationClass. Windows 8.1 and newer, and the caller has to be
 /// elevated: without it the query returns `STATUS_ACCESS_DENIED`. Carries
@@ -470,9 +482,13 @@ pub enum SnapshotKind {
 
 impl SnapshotKind {
     /// Distance between two thread records of this snapshot.
+    ///
+    /// Class 5 lays them out as `SYSTEM_THREAD_INFORMATION` (80 bytes) and
+    /// class 148 as `SYSTEM_EXTENDED_THREAD_INFORMATION` (136 bytes). Both are
+    /// multiples of 8, so every record in the array stays 8-byte aligned.
     fn thread_stride(self) -> usize {
         match self {
-            Self::Basic => size_of::<SYSTEM_THREADS>(),
+            Self::Basic => size_of::<SYSTEM_THREAD_INFORMATION>(),
             Self::Full => size_of::<SYSTEM_EXTENDED_THREAD_INFORMATION>(),
         }
     }
@@ -526,6 +542,9 @@ pub fn query_system_processes() -> Option<SystemProcessSnapshot> {
 fn query_system_info_class(class: u32) -> Option<Vec<u64>> {
     let query = nt_query_system_information()?;
     let mut words = vec![0u64; 0];
+    // A `Vec<u64>` is allocated 8-byte aligned, which is what the
+    // `SYSTEM_PROCESS_INFORMATION` structures in the snapshot require.
+    debug_assert_eq!(words.as_ptr() as usize % 8, 0);
 
     for _ in 0..8 {
         let mut ret_len: u32 = 0;
@@ -555,78 +574,34 @@ fn query_system_info_class(class: u32) -> Option<Vec<u64>> {
     None
 }
 
-/// Decoded `SYSTEM_THREADS`, with the raw handles already narrowed to ids.
-pub struct ThreadInfo {
+/// One thread of a process, decoded from a `SYSTEM_THREAD_INFORMATION`.
+///
+/// The raw handles are narrowed to ids and the times are converted, so this is
+/// what the rest of the crate works with; the kernel buffer is not kept alive
+/// for it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ThreadSnapshot {
     pub tid: i32,
+    /// Owning process id.
+    pub pid: i32,
     pub create_time: i64,
     pub kernel_time: u64,
     pub user_time: u64,
     pub priority: i32,
 }
 
-/// The thread records trailing a `SYSTEM_PROCESS_INFORMATION`.
-///
-/// Held as a base pointer plus a stride rather than a `&[SYSTEM_THREADS]`:
-/// the records are `SYSTEM_EXTENDED_THREAD_INFORMATION` (136 bytes) in a full
-/// snapshot, of which only the leading `SYSTEM_THREADS` part is read, and
-/// neither variant is guaranteed to sit on an 8-byte boundary.
-pub struct ThreadSlice<'a> {
-    base: *const u8,
-    stride: usize,
-    len: usize,
-    /// Owning process id, used to confirm the layout is what we expect.
-    pid: usize,
-    _lifetime: PhantomData<&'a [u64]>,
-}
-
-impl ThreadSlice<'_> {
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    pub fn get(&self, index: usize) -> Option<ThreadInfo> {
-        if index >= self.len {
-            return None;
-        }
-
-        // SAFETY: `index < len` and `len` was clamped so that
-        // `base + (len - 1) * stride + size_of` stays inside the entry. The
-        // record is copied because it can be misaligned.
-        let thread: SYSTEM_THREADS = unsafe {
-            self.base
-                .add(index * self.stride)
-                .cast::<SYSTEM_THREADS>()
-                .read_unaligned()
-        };
-
-        // Every thread carries its owning process id. If a future Windows
-        // release moves the fields around this will not match, and the entry is
-        // dropped instead of being read as garbage.
-        if thread.ClientId.UniqueProcess as usize != self.pid {
-            return None;
-        }
-
-        Some(ThreadInfo {
-            tid: thread.ClientId.UniqueThread as usize as i32,
-            create_time: thread.CreateTime,
-            kernel_time: thread.KernelTime as u64,
-            user_time: thread.UserTime as u64,
-            priority: thread.Priority,
-        })
-    }
-}
-
 /// One entry of a snapshot: the process header plus everything that depends on
 /// knowing where the entry begins and ends.
 ///
-/// The header is a copy rather than a borrow. Entries of a full snapshot are
-/// only guaranteed to be even-aligned - variable-length data such as a package
-/// name makes `NextEntryOffset` arbitrary - so a `&SYSTEM_PROCESS_INFORMATION`
-/// over the buffer would be misaligned often enough to matter.
+/// The header is borrowed straight from the `Vec<u64>` snapshot rather than
+/// copied. The buffer is 8-byte aligned (it is a `Vec<u64>`), and the kernel
+/// places each entry on an 8-byte boundary (`NextEntryOffset` is a multiple of
+/// 8), so a `&SYSTEM_PROCESS_INFORMATION` over the buffer is always aligned.
 pub struct ProcessEntry<'a> {
     buf: &'a [u64],
-    /// Unaligned copy of the entry's leading `SYSTEM_PROCESS_INFORMATION`.
-    header: SYSTEM_PROCESS_INFORMATION,
+    /// The entry's leading `SYSTEM_PROCESS_INFORMATION`, borrowed from the
+    /// snapshot buffer. Aligned, so it is read directly rather than copied.
+    info: &'a SYSTEM_PROCESS_INFORMATION,
     /// Byte offset of this entry within `buf`.
     start: usize,
     /// Byte offset one past this entry: the bound for its variable-length data.
@@ -636,7 +611,7 @@ pub struct ProcessEntry<'a> {
 
 impl<'a> ProcessEntry<'a> {
     pub fn info(&self) -> &SYSTEM_PROCESS_INFORMATION {
-        &self.header
+        self.info
     }
 
     /// The `ImageName`, reduced to the file name when the snapshot supplied a
@@ -649,7 +624,7 @@ impl<'a> ProcessEntry<'a> {
     /// looks for a '.', so both classes are normalised to the short form -
     /// output must not change just because the caller happened to be elevated.
     pub fn image_name(&self) -> String {
-        let name = unicode_string_to_owned(&self.header.ImageName);
+        let name = unicode_string_to_owned(&self.info.ImageName);
         match self.kind {
             SnapshotKind::Basic => name,
             SnapshotKind::Full => match name.rsplit('\\').next() {
@@ -659,29 +634,53 @@ impl<'a> ProcessEntry<'a> {
         }
     }
 
-    /// The `Threads[]` flexible array trailing the process header.
+    /// The `Threads[]` flexible array trailing the process header, decoded into
+    /// owned [`ThreadSnapshot`]s.
     ///
     /// `NumberOfThreads` is the count the kernel stored. For every entry except
     /// the last, the following entry (at `NextEntryOffset`) bounds the array;
     /// the last entry has `NextEntryOffset == 0` and is bounded by the buffer,
-    /// which the kernel sized for exactly `NumberOfThreads` records.
-    pub fn threads(&self) -> ThreadSlice<'a> {
-        let header = size_of::<SYSTEM_PROCESS_INFORMATION>();
+    /// which the kernel sized for exactly `NumberOfThreads` records. Records
+    /// that would reach past the entry are clipped, so nothing is read outside
+    /// the entry it belongs to.
+    pub fn threads(&self) -> Vec<ThreadSnapshot> {
         let stride = self.kind.thread_stride();
-        let first = self.start.saturating_add(header);
+        let first = self
+            .start
+            .saturating_add(size_of::<SYSTEM_PROCESS_INFORMATION>());
 
         let available = self.end.saturating_sub(first);
-        let wanted = (self.header.NumberOfThreads as usize).saturating_mul(stride);
+        let wanted = (self.info.NumberOfThreads as usize).saturating_mul(stride);
         let len = wanted.min(available) / stride;
 
-        ThreadSlice {
-            // SAFETY: `first` is inside `buf`, which outlives `'a`.
-            base: unsafe { self.buf.as_ptr().cast::<u8>().add(first) },
-            stride,
-            len,
-            pid: self.header.UniqueProcessId as usize,
-            _lifetime: PhantomData,
+        let mut ret = Vec::with_capacity(len);
+        // `info` borrows the entry that starts at `start`, so this is
+        // `start + 256`: inside the buffer, and 8-byte aligned like every
+        // entry. Each stride is a multiple of 8, so every record is aligned
+        // too, and `len` was clamped so the last one stays inside the entry.
+        let base = self.info.Threads.as_ptr().cast::<u8>();
+        let pid = self.info.UniqueProcessId as usize as i32;
+
+        for index in 0..len {
+            // SAFETY: `base + index * stride` is inside the entry (`index <
+            // len`) and 8-byte aligned, so a `&SYSTEM_THREAD_INFORMATION`
+            // over it is valid. Both record types start with that structure
+            // (see the `ThreadInfo` offset assertion), which is why the stride
+            // is the only thing that differs between the two classes.
+            let thread: &SYSTEM_THREAD_INFORMATION =
+                unsafe { &*base.add(index * stride).cast::<SYSTEM_THREAD_INFORMATION>() };
+
+            ret.push(ThreadSnapshot {
+                tid: thread.ClientId.UniqueThread as usize as i32,
+                pid,
+                create_time: thread.CreateTime,
+                kernel_time: thread.KernelTime as u64,
+                user_time: thread.UserTime as u64,
+                priority: thread.Priority,
+            });
         }
+
+        ret
     }
 
     /// The process user SID from the extension, as the raw `SID` bytes.
@@ -701,7 +700,7 @@ impl<'a> ProcessEntry<'a> {
         let base = self
             .start
             .checked_add(header)?
-            .checked_add((self.header.NumberOfThreads as usize).checked_mul(stride)?)?;
+            .checked_add((self.info.NumberOfThreads as usize).checked_mul(stride)?)?;
 
         // The fixed prefix we read must fit inside the entry; the variable
         // length data trailing it is reached only through the offsets.
@@ -715,14 +714,16 @@ impl<'a> ProcessEntry<'a> {
     pub fn user_sid(&self) -> Option<SID_MAX> {
         let base = self.extension_base()?;
 
-        // SAFETY: `extension_base` already verified `base + prefix <= end`.
-        let fields: SYSTEM_PROCESS_INFORMATION_EXTENSION = unsafe {
-            self.buf
+        // SAFETY: `extension_base` already verified `base + prefix <= end`, and
+        // `base` is a multiple of 8 (`start` + header + N*stride), so the
+        // extension is aligned; borrow it instead of copying it out.
+        let fields: &SYSTEM_PROCESS_INFORMATION_EXTENSION = unsafe {
+            &*self
+                .buf
                 .as_ptr()
                 .cast::<u8>()
                 .add(base)
                 .cast::<SYSTEM_PROCESS_INFORMATION_EXTENSION>()
-                .read_unaligned()
         };
 
         if fields.UserSidOffset == 0 {
@@ -744,14 +745,15 @@ impl<'a> ProcessEntry<'a> {
     pub fn classification(&self) -> Option<u32> {
         let base = self.extension_base()?;
         // `Flags` sits at offset 48 within the extension; `Classification` is
-        // its bits 1..=4.
+        // its bits 1..=4. `base` is 8-aligned, so a `u32` read at `base + 48`
+        // is aligned.
         let flags: u32 = unsafe {
             self.buf
                 .as_ptr()
                 .cast::<u8>()
                 .add(base + offset_of!(SYSTEM_PROCESS_INFORMATION_EXTENSION, Flags))
                 .cast::<u32>()
-                .read_unaligned()
+                .read()
         };
         Some((flags >> 1) & 0xF)
     }
@@ -834,23 +836,23 @@ impl<'a> Iterator for ProcessIter<'a> {
             return None;
         }
 
-        // SAFETY: `offset + size_of <= limit`, so the header lies wholly inside
-        // the buffer. Copied rather than borrowed: entries of a full snapshot
-        // are not guaranteed to be 8-byte aligned.
-        let info: SYSTEM_PROCESS_INFORMATION = unsafe {
-            self.snapshot
+        // SAFETY: the buffer is a `Vec<u64>`, so it is 8-byte aligned, and the
+        // kernel lays each entry on an 8-byte boundary (`NextEntryOffset` is a
+        // multiple of 8). `offset + size_of <= limit`, so the header is fully
+        // inside the buffer and aligned; borrow it directly instead of copying.
+        debug_assert_eq!(offset % 8, 0);
+        let info: &SYSTEM_PROCESS_INFORMATION = unsafe {
+            &*self
+                .snapshot
                 .words
                 .as_ptr()
                 .cast::<u8>()
                 .add(offset)
                 .cast::<SYSTEM_PROCESS_INFORMATION>()
-                .read_unaligned()
         };
 
         // `NextEntryOffset == 0` marks the last entry. An offset that would not
         // move past this header is malformed - stop rather than loop forever.
-        // Alignment is deliberately not required: a full snapshot pads entries
-        // to 2 bytes, so demanding 8 would silently truncate the process list.
         let next = info.NextEntryOffset as usize;
         let end = if next == 0 || next < header {
             limit
@@ -861,7 +863,7 @@ impl<'a> Iterator for ProcessIter<'a> {
 
         Some(ProcessEntry {
             buf: &self.snapshot.words,
-            header: info,
+            info,
             start: offset,
             end,
             kind: self.snapshot.kind,
@@ -1162,6 +1164,140 @@ mod tests {
             kind: SnapshotKind::Basic,
         };
         assert_eq!(snap.iter().next().unwrap().classification(), None);
+    }
+
+    /// One thread record, zeroed apart from the fields the crate reads.
+    fn thread_record(tid: usize, pid: usize) -> SYSTEM_THREAD_INFORMATION {
+        let mut thread: SYSTEM_THREAD_INFORMATION = unsafe { std::mem::zeroed() };
+        thread.KernelTime = 100;
+        thread.UserTime = 200;
+        thread.CreateTime = 1_234_567;
+        thread.ClientId = CLIENT_ID {
+            UniqueProcess: pid as HANDLE,
+            UniqueThread: tid as HANDLE,
+        };
+        thread.Priority = 8;
+        thread
+    }
+
+    /// Widens a record into the layout a full snapshot uses: the leading
+    /// `SYSTEM_THREAD_INFORMATION` followed by the extended pointers.
+    fn extend(thread: SYSTEM_THREAD_INFORMATION) -> SYSTEM_EXTENDED_THREAD_INFORMATION {
+        SYSTEM_EXTENDED_THREAD_INFORMATION {
+            ThreadInfo: thread,
+            StackBase: ptr::null_mut(),
+            StackLimit: ptr::null_mut(),
+            Win32StartAddress: ptr::null_mut(),
+            TebBaseAddress: ptr::null_mut(),
+            Reserved2: 0,
+            Reserved3: 0,
+            Reserved4: 0,
+        }
+    }
+
+    /// Builds a single-entry snapshot holding `threads` verbatim after the
+    /// process header, while the header claims `number_of_threads` - passing a
+    /// count larger than the records present exercises the bounds clamp.
+    ///
+    /// `T` is whichever thread record the snapshot class uses.
+    fn make_snapshot_with_threads<T>(
+        threads: &[T],
+        number_of_threads: u32,
+        kind: SnapshotKind,
+    ) -> SystemProcessSnapshot {
+        let mut header: SYSTEM_PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
+        // `NextEntryOffset == 0` marks the last entry, which is bounded by the
+        // buffer itself.
+        header.NextEntryOffset = 0;
+        header.NumberOfThreads = number_of_threads;
+        header.UniqueProcessId = 1234 as HANDLE;
+
+        let header_bytes = unsafe {
+            std::slice::from_raw_parts(
+                (&header as *const SYSTEM_PROCESS_INFORMATION).cast::<u8>(),
+                size_of::<SYSTEM_PROCESS_INFORMATION>(),
+            )
+        };
+        let mut bytes: Vec<u8> = header_bytes.to_vec();
+
+        for thread in threads {
+            let record = unsafe {
+                std::slice::from_raw_parts((thread as *const T).cast::<u8>(), size_of::<T>())
+            };
+            bytes.extend_from_slice(record);
+        }
+        // The snapshot is a `Vec<u64>`, so round the buffer up to a whole word.
+        bytes.resize(bytes.len().div_ceil(size_of::<u64>()) * size_of::<u64>(), 0);
+
+        let mut words = vec![0u64; bytes.len() / size_of::<u64>()];
+        // SAFETY: `words` holds exactly `bytes.len()` bytes.
+        unsafe {
+            ptr::copy_nonoverlapping(bytes.as_ptr(), words.as_mut_ptr().cast::<u8>(), bytes.len());
+        }
+
+        SystemProcessSnapshot { words, kind }
+    }
+
+    #[test]
+    fn threads_returns_every_record() {
+        let records = [
+            thread_record(11, 1234),
+            thread_record(12, 1234),
+            thread_record(13, 1234),
+        ];
+        let snap = make_snapshot_with_threads(&records, 3, SnapshotKind::Basic);
+        let entry = snap.iter().next().expect("one entry");
+
+        let got = entry.threads();
+        assert_eq!(got.len(), 3);
+        assert_eq!(got[0].tid, 11);
+        assert_eq!(got[1].tid, 12);
+        assert_eq!(got[2].tid, 13);
+        assert_eq!(got[0].pid, 1234);
+        assert_eq!(got[0].create_time, 1_234_567);
+        assert_eq!(got[0].kernel_time, 100);
+        assert_eq!(got[0].user_time, 200);
+        assert_eq!(got[2].priority, 8);
+    }
+
+    #[test]
+    fn threads_is_empty_without_records() {
+        let snap =
+            make_snapshot_with_threads::<SYSTEM_THREAD_INFORMATION>(&[], 0, SnapshotKind::Basic);
+        let entry = snap.iter().next().expect("one entry");
+        assert!(entry.threads().is_empty());
+    }
+
+    #[test]
+    fn threads_are_clipped_to_the_entry() {
+        // The header claims three records but only two fit before the buffer
+        // ends; the third must not be handed out.
+        let records = [thread_record(11, 1234), thread_record(12, 1234)];
+        let snap = make_snapshot_with_threads(&records, 3, SnapshotKind::Basic);
+        let entry = snap.iter().next().expect("one entry");
+
+        let got = entry.threads();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[1].tid, 12);
+    }
+
+    #[test]
+    fn threads_of_a_full_snapshot_use_the_wider_stride() {
+        // Class 148 lays the threads out as `SYSTEM_EXTENDED_THREAD_INFORMATION`
+        // (136 bytes) and puts the extension after them, so the records are
+        // found at that stride rather than the 80 of a class-5 snapshot.
+        let records = [
+            extend(thread_record(11, 1234)),
+            extend(thread_record(12, 1234)),
+        ];
+        let snap = make_snapshot_with_threads(&records, 2, SnapshotKind::Full);
+        let entry = snap.iter().next().expect("one entry");
+
+        let got = entry.threads();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].tid, 11);
+        assert_eq!(got[1].tid, 12);
+        assert_eq!(got[0].pid, 1234);
     }
 
     /// `IMAGE_FILE_MACHINE_*` of the architecture this test was built for.

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -235,12 +235,24 @@ pub struct CURDIR {
     pub Handle: HANDLE,
 }
 
+/// `RTL_DRIVE_LETTER_CURDIR` - one entry of the per-drive current-directory
+/// array of `RTL_USER_PROCESS_PARAMETERS`.
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct RTL_DRIVE_LETTER_CURDIR {
+    pub Flags: u16,
+    pub Length: u16,
+    pub TimeStamp: u32,
+    pub DosPath: UNICODE_STRING,
+}
+
 /// The leading, version-stable part of `RTL_USER_PROCESS_PARAMETERS`, up to
-/// and including `CurrentDirectory`.
+/// and including `EnvironmentVersion`.
 ///
-/// The fields after `CurrentDirectory` (`DllPath`, `ImagePathName`,
-/// `CommandLine`, ...) are not needed here; the prefix layout has been stable
-/// since XP.
+/// The fields after `EnvironmentVersion` are not needed here; the prefix
+/// layout has been stable since XP. Note that `EnvironmentSize` is a
+/// `ULONG_PTR` and sits *after* the 32-entry `CurrentDirectories` array, not
+/// right after `Environment`.
 #[repr(C)]
 #[allow(non_snake_case)]
 pub struct RTL_USER_PROCESS_PARAMETERS_PREFIX {
@@ -254,12 +266,40 @@ pub struct RTL_USER_PROCESS_PARAMETERS_PREFIX {
     pub StandardOutput: HANDLE,
     pub StandardError: HANDLE,
     pub CurrentDirectory: CURDIR,
+    pub DllPath: UNICODE_STRING,
+    pub ImagePathName: UNICODE_STRING,
+    pub CommandLine: UNICODE_STRING,
+    pub Environment: *mut c_void,
+    pub StartingX: u32,
+    pub StartingY: u32,
+    pub CountX: u32,
+    pub CountY: u32,
+    pub CountCharsX: u32,
+    pub CountCharsY: u32,
+    pub FillAttribute: u32,
+    pub WindowFlags: u32,
+    pub ShowWindowFlags: u32,
+    pub WindowTitle: UNICODE_STRING,
+    pub DesktopInfo: UNICODE_STRING,
+    pub ShellInfo: UNICODE_STRING,
+    pub RuntimeData: UNICODE_STRING,
+    pub CurrentDirectories: [RTL_DRIVE_LETTER_CURDIR; 32],
+    pub EnvironmentSize: usize,
+    pub EnvironmentVersion: usize,
 }
 
 #[cfg(target_pointer_width = "64")]
 const _: () = assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, CurrentDirectory) == 0x38);
 #[cfg(target_pointer_width = "32")]
 const _: () = assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, CurrentDirectory) == 0x24);
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, Environment) == 0x80);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, Environment) == 0x48);
+#[cfg(target_pointer_width = "64")]
+const _: () = assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, EnvironmentSize) == 0x3F0);
+#[cfg(target_pointer_width = "32")]
+const _: () = assert!(offset_of!(RTL_USER_PROCESS_PARAMETERS_PREFIX, EnvironmentSize) == 0x290);
 
 /// Fixed part of a `SID`: revision, sub-authority count and the 6-byte
 /// identifier authority. `windows-sys` types the trailing sub-authorities as
@@ -1083,6 +1123,31 @@ pub fn process_peb_address(handle: HANDLE) -> Option<usize> {
     }
 
     Some(info.PebBaseAddress as usize)
+}
+
+/// Reads `buf.len()` bytes from the address space of `handle` at `addr`.
+///
+/// `addr` is an address in the target process; it must be readable with the
+/// handle's access rights. Returns `None` when the read fails or reads
+/// nothing.
+pub fn read_process_memory<T>(handle: HANDLE, addr: usize, buf: &mut [T]) -> Option<()> {
+    use std::mem::size_of_val;
+    use windows_sys::Win32::System::Diagnostics::Debug::ReadProcessMemory;
+
+    let mut read: usize = 0;
+    let ok = unsafe {
+        ReadProcessMemory(
+            handle,
+            addr as *const c_void,
+            buf.as_mut_ptr().cast::<c_void>(),
+            size_of_val(buf),
+            &mut read,
+        )
+    };
+    if ok == 0 || read == 0 {
+        return None;
+    }
+    Some(())
 }
 
 /// Copies the characters of `string` out of `buffer`, which must still be

--- a/src/process/ntapi.rs
+++ b/src/process/ntapi.rs
@@ -287,8 +287,8 @@ impl SID_MAX {
             if abbr {
                 write!(&mut ret, "-...-{}", subs[count - 1]).unwrap();
             } else {
-                for i in 1..count {
-                    write!(&mut ret, "-{}", subs[i]).unwrap();
+                for sub in &subs[1..] {
+                    write!(&mut ret, "-{sub}").unwrap();
                 }
             }
         }
@@ -807,9 +807,7 @@ impl<'a> Iterator for ProcessIter<'a> {
         // Alignment is deliberately not required: a full snapshot pads entries
         // to 2 bytes, so demanding 8 would silently truncate the process list.
         let next = info.NextEntryOffset as usize;
-        let end = if next == 0 {
-            limit
-        } else if next < header {
+        let end = if next == 0 || next < header {
             limit
         } else {
             offset.saturating_add(next).min(limit)

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -3,28 +3,23 @@ use chrono::{Local, NaiveDate};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::c_void;
-use std::mem::{MaybeUninit, size_of, zeroed};
+use std::mem::{MaybeUninit, zeroed};
 use std::path::PathBuf;
 use std::ptr;
 use std::thread;
 use std::time::{Duration, Instant};
-use windows_sys::Win32::Foundation::{CloseHandle, FALSE, FILETIME, HANDLE, HMODULE, MAX_PATH};
+use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE};
 use windows_sys::Win32::Security::{
     AdjustTokenPrivileges, GetTokenInformation, LookupAccountSidW, LookupPrivilegeValueW, PSID,
     SE_DEBUG_NAME, SE_PRIVILEGE_ENABLED, SID, TOKEN_ADJUST_PRIVILEGES, TOKEN_GROUPS,
-    TOKEN_PRIVILEGES, TOKEN_QUERY, TOKEN_USER, TokenGroups, TokenUser,
-};
-use windows_sys::Win32::System::Diagnostics::ToolHelp::{
-    CreateToolhelp32Snapshot, PROCESSENTRY32, Process32First, Process32Next, TH32CS_SNAPPROCESS,
-};
-use windows_sys::Win32::System::ProcessStatus::{
-    EnumProcessModulesEx, GetModuleBaseNameW, GetProcessMemoryInfo, K32EnumProcesses,
-    LIST_MODULES_ALL, PROCESS_MEMORY_COUNTERS, PROCESS_MEMORY_COUNTERS_EX,
+    TOKEN_INFORMATION_CLASS, TOKEN_PRIVILEGES, TOKEN_QUERY, TOKEN_USER, TokenGroups, TokenUser,
 };
 use windows_sys::Win32::System::Threading::{
-    GetCurrentProcess, GetPriorityClass, GetProcessIoCounters, GetProcessTimes, IO_COUNTERS,
-    OpenProcess, OpenProcessToken, PROCESS_QUERY_INFORMATION, PROCESS_VM_READ,
+    GetCurrentProcess, OpenProcess, OpenProcessToken, PROCESS_QUERY_INFORMATION,
+    PROCESS_QUERY_LIMITED_INFORMATION,
 };
+
+use super::ntapi;
 
 pub struct ProcessInfo {
     pub pid: i32,
@@ -34,9 +29,9 @@ pub struct ProcessInfo {
     pub cpu_info: CpuInfo,
     pub memory_info: MemoryInfo,
     pub disk_info: DiskInfo,
-    pub user: SidName,
+    pub user: Option<SidName>,
     pub groups: Vec<SidName>,
-    pub priority: u32,
+    pub priority: i32,
     pub thread: i32,
     pub interval: Duration,
 }
@@ -57,6 +52,24 @@ pub struct MemoryInfo {
     pub private_usage: u64,
 }
 
+impl MemoryInfo {
+    /// Used for threads, which do not own memory of their own.
+    fn empty() -> Self {
+        Self {
+            page_fault_count: 0,
+            peak_working_set_size: 0,
+            working_set_size: 0,
+            quota_peak_paged_pool_usage: 0,
+            quota_paged_pool_usage: 0,
+            quota_peak_non_paged_pool_usage: 0,
+            quota_non_paged_pool_usage: 0,
+            page_file_usage: 0,
+            peak_page_file_usage: 0,
+            private_usage: 0,
+        }
+    }
+}
+
 pub struct DiskInfo {
     pub prev_read: u64,
     pub prev_write: u64,
@@ -71,136 +84,340 @@ pub struct CpuInfo {
     pub curr_user: u64,
 }
 
+#[derive(Clone)]
+pub struct SidName {
+    pub sid: Vec<u64>,
+    pub name: Option<String>,
+    #[allow(dead_code)]
+    pub domainname: Option<String>,
+}
+
 pub fn collect_proc(
     interval: Duration,
-    _with_thread: bool,
-    _show_kthreads: bool,
+    with_thread: bool,
+    show_kthreads: bool,
     _procfs_path: &Option<PathBuf>,
 ) -> Vec<ProcessInfo> {
-    let mut base_procs = Vec::new();
-    let mut ret = Vec::new();
-
     let _ = set_privilege();
 
-    for pid in get_pids() {
-        let handle = get_handle(pid);
+    let started = Instant::now();
+    let prev = take_snapshot(with_thread);
+    thread::sleep(interval);
+    let finished = Instant::now();
+    let curr = take_snapshot(with_thread);
 
-        if let Some(handle) = handle {
-            let times = get_times(handle);
-            let io = get_io(handle);
+    // Several columns divide by this, so never hand out a zero interval.
+    let interval = finished
+        .saturating_duration_since(started)
+        .max(Duration::from_millis(1));
 
-            let time = Instant::now();
+    let prev_procs: HashMap<i32, &ProcSnapshot> = prev.procs.iter().map(|p| (p.pid, p)).collect();
+    let prev_threads: HashMap<i32, &ThreadSnapshot> =
+        prev.threads.iter().map(|t| (t.tid, t)).collect();
 
-            if let (Some((_, _, sys, user)), Some((read, write))) = (times, io) {
-                base_procs.push((pid, sys, user, read, write, time));
-            }
+    let SystemSnapshot { procs, threads } = curr;
+
+    let mut ret = Vec::with_capacity(procs.len());
+
+    for proc in procs {
+        // Idle and System have no parent process; treat them like the kernel
+        // threads other platforms hide behind the same flag.
+        if !show_kthreads
+            && (proc.ppid == 0 /* Idle, System */ || (proc.ppid == 4 /* System */ && !proc.image_name.contains('.')))
+        {
+            continue;
         }
+
+        let prev = prev_procs
+            .get(&proc.pid)
+            .copied()
+            // A recycled pid would otherwise pair up with an unrelated process.
+            .filter(|p| p.create_time == proc.create_time || proc.create_time == 0);
+
+        let (prev_sys, prev_user, prev_read, prev_write) = match prev {
+            Some(p) => (p.kernel_time, p.user_time, p.read, p.write),
+            // Started between the two samples: report no delta.
+            None => (proc.kernel_time, proc.user_time, proc.read, proc.write),
+        };
+
+        let handles = ProcHandles::open(proc.pid);
+
+        let command = handles
+            .any()
+            .and_then(ntapi::process_command_line)
+            .filter(|command| !command.is_empty())
+            .unwrap_or_else(|| image_fallback(&proc));
+
+        let (user, groups) = match handles.full {
+            Some(handle) => (get_user(handle), get_groups(handle)),
+            None => (None, None),
+        };
+        let priority = proc.base_priority;
+
+        ret.push(ProcessInfo {
+            pid: proc.pid,
+            command,
+            ppid: proc.ppid,
+            start_time: filetime_to_local(proc.create_time),
+            cpu_info: CpuInfo {
+                prev_sys,
+                prev_user,
+                curr_sys: proc.kernel_time,
+                curr_user: proc.user_time,
+            },
+            memory_info: proc.memory_info,
+            disk_info: DiskInfo {
+                prev_read,
+                prev_write,
+                curr_read: proc.read,
+                curr_write: proc.write,
+            },
+            user,
+            groups: groups.unwrap_or_default(),
+            priority,
+            thread: proc.thread_count,
+            interval,
+        });
     }
 
-    thread::sleep(interval);
+    if with_thread {
+        let owners: HashMap<i32, usize> = ret
+            .iter()
+            .enumerate()
+            .map(|(idx, p)| (p.pid, idx))
+            .collect();
 
-    let (mut ppids, mut threads) = get_ppid_threads();
-
-    for (pid, prev_sys, prev_user, prev_read, prev_write, prev_time) in base_procs {
-        let ppid = ppids.remove(&pid);
-        let thread = threads.remove(&pid);
-        let handle = get_handle(pid);
-
-        if let Some(handle) = handle {
-            let command = get_command(handle);
-            let memory_info = get_memory_info(handle);
-            let times = get_times(handle);
-            let io = get_io(handle);
-
-            let start_time = if let Some((start, _, _, _)) = times {
-                let time = chrono::Duration::seconds(start as i64 / 10_000_000);
-                let base = NaiveDate::from_ymd_opt(1601, 1, 1)
-                    .and_then(|ndate| ndate.and_hms_opt(0, 0, 0))
-                    .unwrap();
-                let time = base + time;
-                let local = Local.from_utc_datetime(&time);
-                Some(local)
-            } else {
-                None
+        for thread in threads {
+            // Skip threads whose owning process was filtered out above.
+            let Some(&owner) = owners.get(&thread.pid) else {
+                continue;
             };
 
-            let cpu_info = if let Some((_, _, curr_sys, curr_user)) = times {
-                Some(CpuInfo {
+            let prev = prev_threads
+                .get(&thread.tid)
+                .copied()
+                .filter(|p| p.create_time == thread.create_time || thread.create_time == 0);
+            let (prev_sys, prev_user) = match prev {
+                Some(p) => (
+                    thread.kernel_time.saturating_sub(p.kernel_time),
+                    thread.user_time.saturating_sub(p.user_time),
+                ),
+                None => (thread.kernel_time, thread.user_time),
+            };
+
+            let (command, user, groups) = {
+                let parent = &ret[owner];
+                (
+                    parent.command.clone(),
+                    parent.user.clone(),
+                    parent.groups.clone(),
+                )
+            };
+
+            ret.push(ProcessInfo {
+                pid: thread.tid,
+                command,
+                ppid: thread.pid,
+                start_time: filetime_to_local(thread.create_time),
+                cpu_info: CpuInfo {
                     prev_sys,
                     prev_user,
-                    curr_sys,
-                    curr_user,
-                })
-            } else {
-                None
-            };
-
-            let disk_info = if let Some((curr_read, curr_write)) = io {
-                Some(DiskInfo {
-                    prev_read,
-                    prev_write,
-                    curr_read,
-                    curr_write,
-                })
-            } else {
-                None
-            };
-
-            let user = get_user(handle);
-            let groups = get_groups(handle);
-
-            let priority = get_priority(handle);
-
-            let curr_time = Instant::now();
-            let interval = curr_time - prev_time;
-
-            let mut all_ok = true;
-            all_ok &= command.is_some();
-            all_ok &= start_time.is_some();
-            all_ok &= cpu_info.is_some();
-            all_ok &= memory_info.is_some();
-            all_ok &= disk_info.is_some();
-            all_ok &= user.is_some();
-            all_ok &= groups.is_some();
-            all_ok &= thread.is_some();
-
-            if all_ok {
-                let command = command.unwrap();
-                let ppid = ppid.unwrap_or(0);
-                let start_time = start_time.unwrap();
-                let cpu_info = cpu_info.unwrap();
-                let memory_info = memory_info.unwrap();
-                let disk_info = disk_info.unwrap();
-                let user = user.unwrap();
-                let groups = groups.unwrap();
-                let thread = thread.unwrap();
-
-                let proc = ProcessInfo {
-                    pid,
-                    command,
-                    ppid,
-                    start_time,
-                    cpu_info,
-                    memory_info,
-                    disk_info,
-                    user,
-                    groups,
-                    priority,
-                    thread,
-                    interval,
-                };
-
-                ret.push(proc);
-            }
-
-            unsafe {
-                CloseHandle(handle);
-            }
+                    curr_sys: thread.kernel_time,
+                    curr_user: thread.user_time,
+                },
+                memory_info: MemoryInfo::empty(),
+                disk_info: DiskInfo {
+                    prev_read: 0,
+                    prev_write: 0,
+                    curr_read: 0,
+                    curr_write: 0,
+                },
+                user,
+                groups,
+                priority: thread.priority,
+                thread: 1,
+                interval,
+            });
         }
     }
 
     ret
 }
+
+// ---------------------------------------------------------------------------
+// Snapshot
+// ---------------------------------------------------------------------------
+
+struct ProcSnapshot {
+    pid: i32,
+    ppid: i32,
+    thread_count: i32,
+    image_name: String,
+    create_time: i64,
+    kernel_time: u64,
+    user_time: u64,
+    read: u64,
+    write: u64,
+    memory_info: MemoryInfo,
+    base_priority: i32,
+}
+
+struct ThreadSnapshot {
+    tid: i32,
+    pid: i32,
+    create_time: i64,
+    kernel_time: u64,
+    user_time: u64,
+    priority: i32,
+}
+
+struct SystemSnapshot {
+    procs: Vec<ProcSnapshot>,
+    threads: Vec<ThreadSnapshot>,
+}
+
+/// One `NtQuerySystemInformation(SystemProcessInformation)` call covers every
+/// process on the machine - no process handle required.
+fn take_snapshot(with_thread: bool) -> SystemSnapshot {
+    let mut procs = Vec::new();
+    let mut threads = Vec::new();
+
+    let Some(buffer) = ntapi::query_system_processes() else {
+        return SystemSnapshot { procs, threads };
+    };
+
+    for info in ntapi::ProcessIter::new(&buffer) {
+        procs.push(ProcSnapshot {
+            pid: info.UniqueProcessId as usize as i32,
+            ppid: info.InheritedFromUniqueProcessId as usize as i32,
+            thread_count: info.NumberOfThreads as i32,
+            image_name: ntapi::unicode_string_to_owned(&info.ImageName),
+            create_time: info.CreateTime,
+            kernel_time: info.KernelTime as u64,
+            user_time: info.UserTime as u64,
+            read: info.IoCounters.ReadTransferCount,
+            write: info.IoCounters.WriteTransferCount,
+            memory_info: MemoryInfo {
+                page_fault_count: u64::from(info.VirtualMemoryCounters.PageFaultCount),
+                peak_working_set_size: info.VirtualMemoryCounters.PeakWorkingSetSize as u64,
+                working_set_size: info.VirtualMemoryCounters.WorkingSetSize as u64,
+                quota_peak_paged_pool_usage: info.VirtualMemoryCounters.QuotaPeakPagedPoolUsage
+                    as u64,
+                quota_paged_pool_usage: info.VirtualMemoryCounters.QuotaPagedPoolUsage as u64,
+                quota_peak_non_paged_pool_usage: info
+                    .VirtualMemoryCounters
+                    .QuotaPeakNonPagedPoolUsage
+                    as u64,
+                quota_non_paged_pool_usage: info.VirtualMemoryCounters.QuotaNonPagedPoolUsage
+                    as u64,
+                page_file_usage: info.VirtualMemoryCounters.PagefileUsage as u64,
+                peak_page_file_usage: info.VirtualMemoryCounters.PeakPagefileUsage as u64,
+                private_usage: info.PrivatePageCount as u64,
+            },
+            base_priority: info.BasePriority,
+        });
+
+        if with_thread {
+            let pid = info.UniqueProcessId as usize as i32;
+            let slice = info.threads();
+            for idx in 0..slice.len() {
+                let Some(thread) = slice.get(idx) else {
+                    continue;
+                };
+                threads.push(ThreadSnapshot {
+                    tid: thread.tid,
+                    pid,
+                    create_time: thread.create_time,
+                    kernel_time: thread.kernel_time,
+                    user_time: thread.user_time,
+                    priority: thread.priority,
+                });
+            }
+        }
+    }
+
+    SystemSnapshot { procs, threads }
+}
+
+/// Idle and System have no command line and, depending on privileges, no
+/// readable image name either.
+fn image_fallback(proc: &ProcSnapshot) -> String {
+    if !proc.image_name.is_empty() {
+        return proc.image_name.clone();
+    }
+    match proc.pid {
+        0 => String::from("[System Idle Process]"),
+        _ => String::new(),
+    }
+}
+
+fn filetime_to_local(time: i64) -> chrono::DateTime<Local> {
+    let base = NaiveDate::from_ymd_opt(1601, 1, 1)
+        .and_then(|date| date.and_hms_opt(0, 0, 0))
+        .unwrap();
+    let elapsed = chrono::Duration::seconds(time.max(0) / 10_000_000);
+    Local.from_utc_datetime(&(base + elapsed))
+}
+
+// ---------------------------------------------------------------------------
+// Process handles
+// ---------------------------------------------------------------------------
+
+/// `PROCESS_QUERY_INFORMATION` is needed for the token and
+/// `PROCESS_QUERY_LIMITED_INFORMATION` is sufficient for command lines.
+const FULL_ACCESS: u32 = PROCESS_QUERY_INFORMATION;
+/// Protected processes refuse the above but often allow the limited variant,
+/// which is all `ProcessCommandLineInformation` needs.
+const LIMITED_ACCESS: u32 = PROCESS_QUERY_LIMITED_INFORMATION;
+
+struct ProcHandles {
+    full: Option<HANDLE>,
+    limited: Option<HANDLE>,
+}
+
+impl ProcHandles {
+    fn open(pid: i32) -> Self {
+        if pid <= 0 {
+            return Self {
+                full: None,
+                limited: None,
+            };
+        }
+
+        let full = open_process(pid, FULL_ACCESS);
+        let limited = if full.is_some() {
+            None
+        } else {
+            open_process(pid, LIMITED_ACCESS)
+        };
+
+        Self { full, limited }
+    }
+
+    /// Any handle usable for `NtQueryInformationProcess`.
+    fn any(&self) -> Option<HANDLE> {
+        self.full.or(self.limited)
+    }
+}
+
+impl Drop for ProcHandles {
+    fn drop(&mut self) {
+        for handle in [self.full, self.limited].into_iter().flatten() {
+            unsafe {
+                CloseHandle(handle);
+            }
+        }
+    }
+}
+
+fn open_process(pid: i32, access: u32) -> Option<HANDLE> {
+    let handle = unsafe { OpenProcess(access, FALSE, pid as u32) };
+    if handle.is_null() { None } else { Some(handle) }
+}
+
+// ---------------------------------------------------------------------------
+// Privilege / token
+// ---------------------------------------------------------------------------
 
 fn set_privilege() -> bool {
     let handle = unsafe { GetCurrentProcess() };
@@ -211,18 +428,14 @@ fn set_privilege() -> bool {
     }
 
     let mut tps: TOKEN_PRIVILEGES = unsafe { zeroed() };
-    let se_debug_name: Vec<u16> = format!("{}\0", unsafe { *SE_DEBUG_NAME })
-        .encode_utf16()
-        .collect();
     tps.PrivilegeCount = 1;
-    let ret = unsafe {
-        LookupPrivilegeValueW(
-            ptr::null(),
-            se_debug_name.as_ptr(),
-            &mut tps.Privileges[0].Luid,
-        )
-    };
+    // `SE_DEBUG_NAME` is already a NUL terminated wide string.
+    let ret =
+        unsafe { LookupPrivilegeValueW(ptr::null(), SE_DEBUG_NAME, &mut tps.Privileges[0].Luid) };
     if ret == 0 {
+        unsafe {
+            CloseHandle(token);
+        }
         return false;
     }
 
@@ -237,199 +450,97 @@ fn set_privilege() -> bool {
             ptr::null::<u32>() as *mut u32,
         )
     };
-    if ret == 0 {
-        return false;
+
+    unsafe {
+        CloseHandle(token);
     }
 
-    true
-}
-
-fn get_pids() -> Vec<i32> {
-    let dword_size = size_of::<u32>();
-    let mut pids = Vec::with_capacity(10192);
-    let mut cb_needed = 0;
-
-    unsafe { pids.set_len(10192) };
-    let result = unsafe {
-        K32EnumProcesses(
-            pids.as_mut_ptr(),
-            (dword_size * pids.len()) as u32,
-            &mut cb_needed,
-        )
-    };
-    if result == 0 {
-        return Vec::new();
-    }
-    let pids_len = cb_needed / dword_size as u32;
-    unsafe { pids.set_len(pids_len as usize) };
-
-    pids.iter().map(|x| *x as i32).collect()
-}
-
-fn get_ppid_threads() -> (HashMap<i32, i32>, HashMap<i32, i32>) {
-    let mut ppids = HashMap::new();
-    let mut threads = HashMap::new();
-
-    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
-    let mut entry: PROCESSENTRY32 = unsafe { zeroed() };
-    entry.dwSize = size_of::<PROCESSENTRY32>() as u32;
-    let mut not_the_end = unsafe { Process32First(snapshot, &mut entry) };
-
-    while not_the_end != 0 {
-        ppids.insert(entry.th32ProcessID as i32, entry.th32ParentProcessID as i32);
-        threads.insert(entry.th32ProcessID as i32, entry.cntThreads as i32);
-        not_the_end = unsafe { Process32Next(snapshot, &mut entry) };
-    }
-
-    unsafe { CloseHandle(snapshot) };
-
-    (ppids, threads)
-}
-
-fn get_handle(pid: i32) -> Option<HANDLE> {
-    if pid == 0 {
-        return None;
-    }
-
-    let handle = unsafe {
-        OpenProcess(
-            PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
-            FALSE,
-            pid as u32,
-        )
-    };
-
-    if handle == std::ptr::null_mut() {
-        None
-    } else {
-        Some(handle)
-    }
-}
-
-fn get_times(handle: HANDLE) -> Option<(u64, u64, u64, u64)> {
-    let mut start: FILETIME = unsafe { zeroed() };
-    let mut exit: FILETIME = unsafe { zeroed() };
-    let mut sys: FILETIME = unsafe { zeroed() };
-    let mut user: FILETIME = unsafe { zeroed() };
-
-    let ret = unsafe {
-        GetProcessTimes(
-            handle,
-            &mut start as *mut FILETIME,
-            &mut exit as *mut FILETIME,
-            &mut sys as *mut FILETIME,
-            &mut user as *mut FILETIME,
-        )
-    };
-
-    let start = u64::from(start.dwHighDateTime) << 32 | u64::from(start.dwLowDateTime);
-    let exit = u64::from(exit.dwHighDateTime) << 32 | u64::from(exit.dwLowDateTime);
-    let sys = u64::from(sys.dwHighDateTime) << 32 | u64::from(sys.dwLowDateTime);
-    let user = u64::from(user.dwHighDateTime) << 32 | u64::from(user.dwLowDateTime);
-
-    if ret != 0 {
-        Some((start, exit, sys, user))
-    } else {
-        None
-    }
-}
-
-fn get_memory_info(handle: HANDLE) -> Option<MemoryInfo> {
-    let mut pmc: PROCESS_MEMORY_COUNTERS_EX = unsafe { zeroed() };
-    let ret = unsafe {
-        GetProcessMemoryInfo(
-            handle,
-            &mut pmc as *mut PROCESS_MEMORY_COUNTERS_EX as *mut c_void
-                as *mut PROCESS_MEMORY_COUNTERS,
-            size_of::<PROCESS_MEMORY_COUNTERS_EX>() as u32,
-        )
-    };
-
-    if ret != 0 {
-        let info = MemoryInfo {
-            page_fault_count: u64::from(pmc.PageFaultCount),
-            peak_working_set_size: pmc.PeakWorkingSetSize as u64,
-            working_set_size: pmc.WorkingSetSize as u64,
-            quota_peak_paged_pool_usage: pmc.QuotaPeakPagedPoolUsage as u64,
-            quota_paged_pool_usage: pmc.QuotaPagedPoolUsage as u64,
-            quota_peak_non_paged_pool_usage: pmc.QuotaPeakNonPagedPoolUsage as u64,
-            quota_non_paged_pool_usage: pmc.QuotaNonPagedPoolUsage as u64,
-            page_file_usage: pmc.PagefileUsage as u64,
-            peak_page_file_usage: pmc.PeakPagefileUsage as u64,
-            private_usage: pmc.PrivateUsage as u64,
-        };
-        Some(info)
-    } else {
-        None
-    }
-}
-
-fn get_command(handle: HANDLE) -> Option<String> {
-    let mut exe_buf = [0u16; MAX_PATH as usize + 1];
-    let h_mod: HMODULE = std::ptr::null_mut();
-    let mut cb_needed = 0;
-
-    let ret = unsafe {
-        EnumProcessModulesEx(
-            handle,
-            h_mod as *mut HMODULE,
-            size_of::<u32>() as u32,
-            &mut cb_needed,
-            LIST_MODULES_ALL,
-        )
-    };
-    if ret == 0 {
-        return None;
-    }
-
-    let ret = unsafe { GetModuleBaseNameW(handle, h_mod, exe_buf.as_mut_ptr(), MAX_PATH + 1) };
-
-    let mut pos = 0;
-    for x in exe_buf.iter() {
-        if *x == 0 {
-            break;
-        }
-        pos += 1;
-    }
-
-    if ret != 0 {
-        Some(String::from_utf16_lossy(&exe_buf[..pos]))
-    } else {
-        None
-    }
-}
-
-fn get_io(handle: HANDLE) -> Option<(u64, u64)> {
-    let mut io: IO_COUNTERS = unsafe { zeroed() };
-    let ret = unsafe { GetProcessIoCounters(handle, &mut io) };
-
-    if ret != 0 {
-        Some((io.ReadTransferCount, io.WriteTransferCount))
-    } else {
-        None
-    }
-}
-
-pub struct SidName {
-    pub sid: Vec<u64>,
-    pub name: Option<String>,
-    #[allow(dead_code)]
-    pub domainname: Option<String>,
+    ret != 0
 }
 
 fn get_user(handle: HANDLE) -> Option<SidName> {
     let mut token: HANDLE = unsafe { zeroed() };
     let ret = unsafe { OpenProcessToken(handle, TOKEN_QUERY, &mut token) };
-
     if ret == 0 {
         return None;
     }
 
+    let sid = get_token_information(token, TokenUser);
+    unsafe {
+        CloseHandle(token);
+    }
+
+    // The SID pointer lives inside this buffer, so it has to stay alive for
+    // as long as `psid` is used.
+    let buf = sid?;
+
+    #[allow(clippy::cast_ptr_alignment)]
+    let token_user = buf.as_ptr() as *const TOKEN_USER;
+    let psid = unsafe { (*token_user).User.Sid };
+
+    let (name, domainname) = match get_name_cached(psid) {
+        Some((name, domainname)) => (Some(name), Some(domainname)),
+        None => (None, None),
+    };
+
+    Some(SidName {
+        sid: get_sid(psid),
+        name,
+        domainname,
+    })
+}
+
+fn get_groups(handle: HANDLE) -> Option<Vec<SidName>> {
+    let mut token: HANDLE = unsafe { zeroed() };
+    let ret = unsafe { OpenProcessToken(handle, TOKEN_QUERY, &mut token) };
+    if ret == 0 {
+        return None;
+    }
+
+    let groups = get_token_information(token, TokenGroups);
+    unsafe {
+        CloseHandle(token);
+    }
+
+    // The SID pointers live inside this buffer, so it has to outlive them.
+    let buf = groups?;
+
+    let mut ret = Vec::new();
+    #[allow(clippy::cast_ptr_alignment)]
+    let token_groups = buf.as_ptr() as *const TOKEN_GROUPS;
+
+    unsafe {
+        let sa = (*token_groups).Groups.as_ptr();
+        for i in 0..(*token_groups).GroupCount {
+            let psid = (*sa.offset(i as isize)).Sid;
+            let (name, domainname) = if let Some((x, y)) = get_name_cached(psid) {
+                (Some(x), Some(y))
+            } else {
+                (None, None)
+            };
+
+            ret.push(SidName {
+                sid: get_sid(psid),
+                name,
+                domainname,
+            });
+        }
+    }
+
+    Some(ret)
+}
+
+/// Queries a token, returning the buffer that owns the result. Callers must
+/// keep it alive: the returned information contains pointers into it.
+fn get_token_information(
+    token: HANDLE,
+    class: TOKEN_INFORMATION_CLASS,
+) -> Option<Vec<MaybeUninit<u8>>> {
     let mut cb_needed = 0;
     let _ = unsafe {
         GetTokenInformation(
             token,
-            TokenUser,
+            class,
             ptr::null::<c_void>() as *mut c_void,
             0,
             &mut cb_needed,
@@ -444,92 +555,14 @@ fn get_user(handle: HANDLE) -> Option<SidName> {
     let ret = unsafe {
         GetTokenInformation(
             token,
-            TokenUser,
+            class,
             buf.as_mut_ptr() as *mut c_void,
             cb_needed,
             &mut cb_needed,
         )
     };
 
-    if ret == 0 {
-        return None;
-    }
-
-    #[allow(clippy::cast_ptr_alignment)]
-    let token_user = buf.as_ptr() as *const TOKEN_USER;
-    let psid = unsafe { (*token_user).User.Sid };
-
-    let sid = get_sid(psid);
-    let (name, domainname) = if let Some((x, y)) = get_name_cached(psid) {
-        (Some(x), Some(y))
-    } else {
-        (None, None)
-    };
-
-    Some(SidName {
-        sid,
-        name,
-        domainname,
-    })
-}
-
-fn get_groups(handle: HANDLE) -> Option<Vec<SidName>> {
-    unsafe {
-        let mut token: HANDLE = zeroed();
-        let ret = OpenProcessToken(handle, TOKEN_QUERY, &mut token);
-
-        if ret == 0 {
-            return None;
-        }
-
-        let mut cb_needed = 0;
-        let _ = GetTokenInformation(
-            token,
-            TokenGroups,
-            ptr::null::<c_void>() as *mut c_void,
-            0,
-            &mut cb_needed,
-        );
-
-        let mut buf: Vec<MaybeUninit<u8>> = Vec::with_capacity(cb_needed as usize);
-        buf.set_len(cb_needed as usize);
-
-        let ret = GetTokenInformation(
-            token,
-            TokenGroups,
-            buf.as_mut_ptr() as *mut c_void,
-            cb_needed,
-            &mut cb_needed,
-        );
-
-        if ret == 0 {
-            return None;
-        }
-
-        #[allow(clippy::cast_ptr_alignment)]
-        let token_groups = buf.as_ptr() as *const TOKEN_GROUPS;
-
-        let mut ret = Vec::new();
-        let sa = (*token_groups).Groups.as_ptr();
-        for i in 0..(*token_groups).GroupCount {
-            let psid = (*sa.offset(i as isize)).Sid;
-            let sid = get_sid(psid);
-            let (name, domainname) = if let Some((x, y)) = get_name_cached(psid) {
-                (Some(x), Some(y))
-            } else {
-                (None, None)
-            };
-
-            let sid_name = SidName {
-                sid,
-                name,
-                domainname,
-            };
-            ret.push(sid_name);
-        }
-
-        Some(ret)
-    }
+    if ret == 0 { None } else { Some(buf) }
 }
 
 fn get_sid(psid: PSID) -> Vec<u64> {
@@ -556,19 +589,25 @@ fn get_sid(psid: PSID) -> Vec<u64> {
     }
 }
 
+/// Account name and domain name, cached per SID.
+type AccountName = Option<(String, String)>;
+
+// Keyed by the SID itself rather than by its address: every query allocates a
+// fresh buffer, and a freed one gets its address recycled by the next query,
+// which would hand back another account's name.
 thread_local!(
-    pub static NAME_CACHE: RefCell<HashMap<PSID, Option<(String, String)>>> =
-        RefCell::new(HashMap::new());
+    pub static NAME_CACHE: RefCell<HashMap<Vec<u64>, AccountName>> = RefCell::new(HashMap::new());
 );
 
 fn get_name_cached(psid: PSID) -> Option<(String, String)> {
+    let key = get_sid(psid);
     NAME_CACHE.with(|c| {
         let mut c = c.borrow_mut();
-        if let Some(x) = c.get(&psid) {
+        if let Some(x) = c.get(&key) {
             x.clone()
         } else {
             let x = get_name(psid);
-            c.insert(psid, x.clone());
+            c.insert(key, x.clone());
             x
         }
     })
@@ -627,8 +666,4 @@ fn from_wide_ptr(ptr: *const u16) -> String {
         .unwrap();
     let slice = unsafe { std::slice::from_raw_parts(ptr, len) };
     OsString::from_wide(slice).to_string_lossy().into_owned()
-}
-
-fn get_priority(handle: HANDLE) -> u32 {
-    unsafe { GetPriorityClass(handle) }
 }

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -21,6 +21,9 @@ use windows_sys::Win32::System::Threading::{
 
 use super::ntapi;
 
+/// Re-export the owned SID type so callers can use `crate::process::SID_MAX`.
+pub use super::ntapi::SID_MAX;
+
 pub struct ProcessInfo {
     pub pid: i32,
     pub command: String,
@@ -29,8 +32,8 @@ pub struct ProcessInfo {
     pub cpu_info: CpuInfo,
     pub memory_info: MemoryInfo,
     pub disk_info: DiskInfo,
-    pub user: Option<SidName>,
-    pub groups: Vec<SidName>,
+    pub user: Option<SID_MAX>,
+    pub groups: Vec<SID_MAX>,
     pub priority: i32,
     pub thread: i32,
     pub interval: Duration,
@@ -82,14 +85,6 @@ pub struct CpuInfo {
     pub prev_user: u64,
     pub curr_sys: u64,
     pub curr_user: u64,
-}
-
-#[derive(Clone)]
-pub struct SidName {
-    pub sid: Vec<u64>,
-    pub name: Option<String>,
-    #[allow(dead_code)]
-    pub domainname: Option<String>,
 }
 
 pub fn collect_proc(
@@ -152,8 +147,7 @@ pub fn collect_proc(
         // opened for processes the snapshot could not name.
         let user = proc
             .user_sid
-            .as_deref()
-            .map(sid_name)
+            .clone()
             .or_else(|| handles.full.and_then(get_user));
         let groups = handles.full.and_then(get_groups);
         let priority = proc.base_priority;
@@ -266,7 +260,7 @@ struct ProcSnapshot {
     base_priority: i32,
     /// Process user SID straight from the snapshot, when it carried one.
     /// `None` means the token has to be opened to learn the user.
-    user_sid: Option<Vec<u64>>,
+    user_sid: Option<SID_MAX>,
     /// Whether this process is one of the kernel's own: System, Secure System,
     /// Registry, Memory Compression. When the full snapshot classified it this
     /// is authoritative; for a basic snapshot it falls back to the classic
@@ -489,7 +483,7 @@ fn set_privilege() -> bool {
     ret != 0
 }
 
-fn get_user(handle: HANDLE) -> Option<SidName> {
+fn get_user(handle: HANDLE) -> Option<SID_MAX> {
     let mut token: HANDLE = unsafe { zeroed() };
     let ret = unsafe { OpenProcessToken(handle, TOKEN_QUERY, &mut token) };
     if ret == 0 {
@@ -509,31 +503,10 @@ fn get_user(handle: HANDLE) -> Option<SidName> {
     let token_user = buf.as_ptr() as *const TOKEN_USER;
     let psid = unsafe { (*token_user).User.Sid };
 
-    Some(sid_name_from_psid(psid))
+    Some(unsafe { SID_MAX::from_psid(psid) })
 }
 
-/// Builds a `SidName` from a SID owned by the caller.
-///
-/// `sid` holds the raw SID bytes as copied by `ntapi`, kept in a `Vec<u64>` so
-/// the `u32` sub-authorities that `PSID` reads stay aligned.
-fn sid_name(sid: &[u64]) -> SidName {
-    sid_name_from_psid(sid.as_ptr() as PSID)
-}
-
-fn sid_name_from_psid(psid: PSID) -> SidName {
-    let (name, domainname) = match get_name_cached(psid) {
-        Some((name, domainname)) => (Some(name), Some(domainname)),
-        None => (None, None),
-    };
-
-    SidName {
-        sid: get_sid(psid),
-        name,
-        domainname,
-    }
-}
-
-fn get_groups(handle: HANDLE) -> Option<Vec<SidName>> {
+fn get_groups(handle: HANDLE) -> Option<Vec<SID_MAX>> {
     let mut token: HANDLE = unsafe { zeroed() };
     let ret = unsafe { OpenProcessToken(handle, TOKEN_QUERY, &mut token) };
     if ret == 0 {
@@ -556,7 +529,7 @@ fn get_groups(handle: HANDLE) -> Option<Vec<SidName>> {
         let sa = (*token_groups).Groups.as_ptr();
         for i in 0..(*token_groups).GroupCount {
             let psid = (*sa.offset(i as isize)).Sid;
-            ret.push(sid_name_from_psid(psid));
+            ret.push(SID_MAX::from_psid(psid));
         }
     }
 
@@ -598,30 +571,6 @@ fn get_token_information(
     if ret == 0 { None } else { Some(buf) }
 }
 
-fn get_sid(psid: PSID) -> Vec<u64> {
-    let mut ret = Vec::new();
-    let psid = psid as *const SID;
-    unsafe {
-        let mut ia = 0;
-        ia |= u64::from((*psid).IdentifierAuthority.Value[0]) << 40;
-        ia |= u64::from((*psid).IdentifierAuthority.Value[1]) << 32;
-        ia |= u64::from((*psid).IdentifierAuthority.Value[2]) << 24;
-        ia |= u64::from((*psid).IdentifierAuthority.Value[3]) << 16;
-        ia |= u64::from((*psid).IdentifierAuthority.Value[4]) << 8;
-        ia |= u64::from((*psid).IdentifierAuthority.Value[5]);
-
-        ret.push(u64::from((*psid).Revision));
-        ret.push(ia);
-        let cnt = (*psid).SubAuthorityCount;
-        let sa = (*psid).SubAuthority.as_ptr();
-        for i in 0..cnt {
-            ret.push(u64::from(*sa.offset(i as isize)));
-        }
-
-        ret
-    }
-}
-
 /// Account name and domain name, cached per SID.
 type AccountName = Option<(String, String)>;
 
@@ -629,63 +578,72 @@ type AccountName = Option<(String, String)>;
 // fresh buffer, and a freed one gets its address recycled by the next query,
 // which would hand back another account's name.
 thread_local!(
-    pub static NAME_CACHE: RefCell<HashMap<Vec<u64>, AccountName>> = RefCell::new(HashMap::new());
+    pub static NAME_CACHE: RefCell<HashMap<SID_MAX, AccountName>> = RefCell::new(HashMap::new());
 );
 
-fn get_name_cached(psid: PSID) -> Option<(String, String)> {
-    let key = get_sid(psid);
-    NAME_CACHE.with(|c| {
-        let mut c = c.borrow_mut();
-        if let Some(x) = c.get(&key) {
-            x.clone()
-        } else {
-            let x = get_name(psid);
-            c.insert(key, x.clone());
-            x
+impl SID_MAX {
+    /// Resolves the account name for this SID at display time, using the
+    /// thread-local cache. Returns `None` when the name cannot be looked up
+    /// (e.g. a protected process or a SID with no resolvable account).
+    pub fn display_name(&self) -> Option<String> {
+        NAME_CACHE
+            .with(|c| {
+                let mut c = c.borrow_mut();
+                if let Some(x) = c.get(self) {
+                    x.clone()
+                } else {
+                    // `SID_MAX` embeds the official `SID` with matching alignment,
+                    // so its address is a valid `PSID`.
+                    let x = self.get_name();
+                    c.insert(*self, x.clone());
+                    x
+                }
+            })
+            .map(|(name, _)| name)
+    }
+
+    fn get_name(&self) -> Option<(String, String)> {
+        let psid = &self.sid as *const SID as PSID;
+        let mut cc_name = 0;
+        let mut cc_domainname = 0;
+        let mut pe_use = 0;
+        unsafe {
+            let _ = LookupAccountSidW(
+                ptr::null::<u16>() as *mut u16,
+                psid,
+                ptr::null::<u16>() as *mut u16,
+                &mut cc_name,
+                ptr::null::<u16>() as *mut u16,
+                &mut cc_domainname,
+                &mut pe_use,
+            );
+
+            if cc_name == 0 || cc_domainname == 0 {
+                return None;
+            }
+
+            let mut name: Vec<u16> = Vec::with_capacity(cc_name as usize);
+            let mut domainname: Vec<u16> = Vec::with_capacity(cc_domainname as usize);
+            name.set_len(cc_name as usize);
+            domainname.set_len(cc_domainname as usize);
+            let ret = LookupAccountSidW(
+                ptr::null::<u16>() as *mut u16,
+                psid,
+                name.as_mut_ptr(),
+                &mut cc_name,
+                domainname.as_mut_ptr(),
+                &mut cc_domainname,
+                &mut pe_use,
+            );
+
+            if ret == 0 {
+                return None;
+            }
+
+            let name = from_wide_ptr(name.as_ptr());
+            let domainname = from_wide_ptr(domainname.as_ptr());
+            Some((name, domainname))
         }
-    })
-}
-
-fn get_name(psid: PSID) -> Option<(String, String)> {
-    let mut cc_name = 0;
-    let mut cc_domainname = 0;
-    let mut pe_use = 0;
-    unsafe {
-        let _ = LookupAccountSidW(
-            ptr::null::<u16>() as *mut u16,
-            psid,
-            ptr::null::<u16>() as *mut u16,
-            &mut cc_name,
-            ptr::null::<u16>() as *mut u16,
-            &mut cc_domainname,
-            &mut pe_use,
-        );
-
-        if cc_name == 0 || cc_domainname == 0 {
-            return None;
-        }
-
-        let mut name: Vec<u16> = Vec::with_capacity(cc_name as usize);
-        let mut domainname: Vec<u16> = Vec::with_capacity(cc_domainname as usize);
-        name.set_len(cc_name as usize);
-        domainname.set_len(cc_domainname as usize);
-        let ret = LookupAccountSidW(
-            ptr::null::<u16>() as *mut u16,
-            psid,
-            name.as_mut_ptr(),
-            &mut cc_name,
-            domainname.as_mut_ptr(),
-            &mut cc_domainname,
-            &mut pe_use,
-        );
-
-        if ret == 0 {
-            return None;
-        }
-
-        let name = from_wide_ptr(name.as_ptr());
-        let domainname = from_wide_ptr(domainname.as_ptr());
-        Some((name, domainname))
     }
 }
 

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -120,11 +120,11 @@ pub fn collect_proc(
     let mut ret = Vec::with_capacity(procs.len());
 
     for proc in procs {
-        // Idle and System have no parent process; treat them like the kernel
-        // threads other platforms hide behind the same flag.
-        if !show_kthreads
-            && (proc.ppid == 0 /* Idle, System */ || (proc.ppid == 4 /* System */ && !proc.image_name.contains('.')))
-        {
+        // Hide the kernel's own processes (Idle, System, Registry, Memory
+        // Compression, ...) unless `--thread` was given. The decision is made
+        // once in `take_snapshot` from the authoritative kernel classification
+        // (or the parent-pid heuristic on a basic snapshot).
+        if !show_kthreads && proc.is_kthread {
             continue;
         }
 
@@ -148,10 +148,14 @@ pub fn collect_proc(
             .filter(|command| !command.is_empty())
             .unwrap_or_else(|| image_fallback(&proc));
 
-        let (user, groups) = match handles.full {
-            Some(handle) => (get_user(handle), get_groups(handle)),
-            None => (None, None),
-        };
+        // The snapshot SID saves an `OpenProcessToken`; the token is only
+        // opened for processes the snapshot could not name.
+        let user = proc
+            .user_sid
+            .as_deref()
+            .map(sid_name)
+            .or_else(|| handles.full.and_then(get_user));
+        let groups = handles.full.and_then(get_groups);
         let priority = proc.base_priority;
 
         ret.push(ProcessInfo {
@@ -260,6 +264,14 @@ struct ProcSnapshot {
     write: u64,
     memory_info: MemoryInfo,
     base_priority: i32,
+    /// Process user SID straight from the snapshot, when it carried one.
+    /// `None` means the token has to be opened to learn the user.
+    user_sid: Option<Vec<u64>>,
+    /// Whether this process is one of the kernel's own: System, Secure System,
+    /// Registry, Memory Compression. When the full snapshot classified it this
+    /// is authoritative; for a basic snapshot it falls back to the classic
+    /// Idle/System parent-pid heuristic. `procs` hides these unless `--thread`.
+    is_kthread: bool,
 }
 
 struct ThreadSnapshot {
@@ -276,8 +288,11 @@ struct SystemSnapshot {
     threads: Vec<ThreadSnapshot>,
 }
 
-/// One `NtQuerySystemInformation(SystemProcessInformation)` call covers every
-/// process on the machine - no process handle required.
+/// One `NtQuerySystemInformation` call covers every process on the machine -
+/// no process handle required.
+///
+/// `SystemFullProcessInformation` is used when it is available, which also
+/// hands over each process' user SID.
 fn take_snapshot(with_thread: bool) -> SystemSnapshot {
     let mut procs = Vec::new();
     let mut threads = Vec::new();
@@ -286,12 +301,26 @@ fn take_snapshot(with_thread: bool) -> SystemSnapshot {
         return SystemSnapshot { procs, threads };
     };
 
-    for info in ntapi::ProcessIter::new(&buffer) {
+    for entry in buffer.iter() {
+        let info = entry.info();
+        let ppid = info.InheritedFromUniqueProcessId as usize as i32;
+        let image_name = entry.image_name();
+
+        // Hide the kernel's own processes. The full snapshot's classification is
+        // authoritative - a non-zero `SYSTEM_PROCESS_CLASSIFICATION` marks System,
+        // Secure System, Registry and Memory Compression, which carry real parent
+        // PIDs and the classic ppid heuristic would miss. The parent-pid rule is
+        // kept as a safety net for Idle (pid 0): the kernel reports it as `Normal`
+        // (classification 0) yet it is not a user process and must stay hidden.
+        let is_kthread = entry.classification().is_some_and(|c| c != 0)
+            || ppid == 0
+            || (ppid == 4 && !image_name.contains('.'));
+
         procs.push(ProcSnapshot {
             pid: info.UniqueProcessId as usize as i32,
-            ppid: info.InheritedFromUniqueProcessId as usize as i32,
+            ppid,
             thread_count: info.NumberOfThreads as i32,
-            image_name: ntapi::unicode_string_to_owned(&info.ImageName),
+            image_name,
             create_time: info.CreateTime,
             kernel_time: info.KernelTime as u64,
             user_time: info.UserTime as u64,
@@ -315,11 +344,13 @@ fn take_snapshot(with_thread: bool) -> SystemSnapshot {
                 private_usage: info.PrivatePageCount as u64,
             },
             base_priority: info.BasePriority,
+            user_sid: entry.user_sid(),
+            is_kthread,
         });
 
         if with_thread {
             let pid = info.UniqueProcessId as usize as i32;
-            let slice = info.threads();
+            let slice = entry.threads();
             for idx in 0..slice.len() {
                 let Some(thread) = slice.get(idx) else {
                     continue;
@@ -478,16 +509,28 @@ fn get_user(handle: HANDLE) -> Option<SidName> {
     let token_user = buf.as_ptr() as *const TOKEN_USER;
     let psid = unsafe { (*token_user).User.Sid };
 
+    Some(sid_name_from_psid(psid))
+}
+
+/// Builds a `SidName` from a SID owned by the caller.
+///
+/// `sid` holds the raw SID bytes as copied by `ntapi`, kept in a `Vec<u64>` so
+/// the `u32` sub-authorities that `PSID` reads stay aligned.
+fn sid_name(sid: &[u64]) -> SidName {
+    sid_name_from_psid(sid.as_ptr() as PSID)
+}
+
+fn sid_name_from_psid(psid: PSID) -> SidName {
     let (name, domainname) = match get_name_cached(psid) {
         Some((name, domainname)) => (Some(name), Some(domainname)),
         None => (None, None),
     };
 
-    Some(SidName {
+    SidName {
         sid: get_sid(psid),
         name,
         domainname,
-    })
+    }
 }
 
 fn get_groups(handle: HANDLE) -> Option<Vec<SidName>> {
@@ -513,17 +556,7 @@ fn get_groups(handle: HANDLE) -> Option<Vec<SidName>> {
         let sa = (*token_groups).Groups.as_ptr();
         for i in 0..(*token_groups).GroupCount {
             let psid = (*sa.offset(i as isize)).Sid;
-            let (name, domainname) = if let Some((x, y)) = get_name_cached(psid) {
-                (Some(x), Some(y))
-            } else {
-                (None, None)
-            };
-
-            ret.push(SidName {
-                sid: get_sid(psid),
-                name,
-                domainname,
-            });
+            ret.push(sid_name_from_psid(psid));
         }
     }
 

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -12,8 +12,8 @@ use std::time::{Duration, Instant};
 use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE};
 use windows_sys::Win32::Security::{
     AdjustTokenPrivileges, GetTokenInformation, LookupAccountSidW, LookupPrivilegeValueW, PSID,
-    SE_DEBUG_NAME, SE_PRIVILEGE_ENABLED, SID, TOKEN_ADJUST_PRIVILEGES, TOKEN_GROUPS,
-    TOKEN_INFORMATION_CLASS, TOKEN_PRIVILEGES, TOKEN_QUERY, TOKEN_USER, TokenGroups, TokenUser,
+    SE_DEBUG_NAME, SE_PRIVILEGE_ENABLED, SID, TOKEN_ADJUST_PRIVILEGES, TOKEN_INFORMATION_CLASS,
+    TOKEN_PRIVILEGES, TOKEN_QUERY, TOKEN_USER, TokenUser,
 };
 use windows_sys::Win32::System::Threading::{
     GetCurrentProcess, OpenProcess, OpenProcessToken, PROCESS_QUERY_INFORMATION,
@@ -67,7 +67,6 @@ pub struct ProcessInfo {
     pub disk_info: DiskInfo,
     pub net_info: NetInfo,
     pub user: Option<SID_MAX>,
-    pub groups: Vec<SID_MAX>,
     pub priority: i32,
     pub thread: i32,
     pub session: i32,
@@ -199,9 +198,10 @@ pub fn collect_proc(
         let file_name = image_fallback(&proc);
 
         // The snapshot SID saves an `OpenProcessToken`; the token is only
-        // opened for processes the snapshot could not name.
+        // opened for processes the snapshot could not name. The group list is
+        // deliberately not collected here - `Group` and `Gid` query it
+        // themselves, so that only enabling one of them pays for it.
         let user = proc.user_sid.or_else(|| handles.full.and_then(get_user));
-        let groups = handles.full.and_then(get_groups);
         let priority = proc.base_priority;
 
         ret.push(ProcessInfo {
@@ -231,7 +231,6 @@ pub fn collect_proc(
             // Last: this moves out of `proc`, which `prev` may still borrow.
             memory_info: proc.memory_info,
             user,
-            groups: groups.unwrap_or_default(),
             priority,
             thread: proc.thread_count,
             session: proc.session_id as i32,
@@ -265,13 +264,12 @@ pub fn collect_proc(
                 None => (thread.kernel_time, thread.user_time),
             };
 
-            let (command, file_name, user, groups, session) = {
+            let (command, file_name, user, session) = {
                 let parent = &ret[owner];
                 (
                     parent.command.clone(),
                     parent.file_name.clone(),
                     parent.user,
-                    parent.groups.clone(),
                     parent.session,
                 )
             };
@@ -304,7 +302,6 @@ pub fn collect_proc(
                     curr_send: 0,
                 },
                 user,
-                groups,
                 priority: thread.priority,
                 thread: 1,
                 session,
@@ -603,7 +600,7 @@ fn get_user(handle: HANDLE) -> Option<SID_MAX> {
         return None;
     }
 
-    let sid = get_token_information(token, TokenUser);
+    let sid = token_information(token, TokenUser);
     unsafe {
         CloseHandle(token);
     }
@@ -619,39 +616,12 @@ fn get_user(handle: HANDLE) -> Option<SID_MAX> {
     Some(unsafe { SID_MAX::from_psid(psid) })
 }
 
-fn get_groups(handle: HANDLE) -> Option<Vec<SID_MAX>> {
-    let mut token: HANDLE = unsafe { zeroed() };
-    let ret = unsafe { OpenProcessToken(handle, TOKEN_QUERY, &mut token) };
-    if ret == 0 {
-        return None;
-    }
-
-    let groups = get_token_information(token, TokenGroups);
-    unsafe {
-        CloseHandle(token);
-    }
-
-    // The SID pointers live inside this buffer, so it has to outlive them.
-    let buf = groups?;
-
-    let mut ret = Vec::new();
-    #[allow(clippy::cast_ptr_alignment)]
-    let token_groups = buf.as_ptr() as *const TOKEN_GROUPS;
-
-    unsafe {
-        let sa = (*token_groups).Groups.as_ptr();
-        for i in 0..(*token_groups).GroupCount {
-            let psid = (*sa.offset(i as isize)).Sid;
-            ret.push(SID_MAX::from_psid(psid));
-        }
-    }
-
-    Some(ret)
-}
-
 /// Queries a token, returning the buffer that owns the result. Callers must
 /// keep it alive: the returned information contains pointers into it.
-fn get_token_information(
+///
+/// Public so that columns can read a token class the collection does not
+/// gather itself - `Group` reads `TokenGroups` this way, on demand.
+pub fn token_information(
     token: HANDLE,
     class: TOKEN_INFORMATION_CLASS,
 ) -> Option<Vec<MaybeUninit<u8>>> {

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -29,7 +29,12 @@ pub use super::ntapi::process_image_machine;
 
 pub struct ProcessInfo {
     pub pid: i32,
-    pub command: String,
+    /// Command line of the process, or `None` when the process exposes none
+    /// (e.g. System, Idle). Falls back to `file_name` at display time.
+    pub command: Option<String>,
+    /// Image (executable) name, used as the Command fallback and by the
+    /// FileName column.
+    pub file_name: String,
     pub ppid: i32,
     pub start_time: chrono::DateTime<chrono::Local>,
     pub cpu_info: CpuInfo,
@@ -39,6 +44,7 @@ pub struct ProcessInfo {
     pub groups: Vec<SID_MAX>,
     pub priority: i32,
     pub thread: i32,
+    pub session: i32,
     pub interval: Duration,
 }
 
@@ -143,8 +149,12 @@ pub fn collect_proc(
         let command = handles
             .any()
             .and_then(ntapi::process_command_line)
-            .filter(|command| !command.is_empty())
-            .unwrap_or_else(|| image_fallback(&proc));
+            .filter(|command| !command.is_empty());
+
+        // `command` holds only the command line (when one is exposed); `file_name`
+        // is the image name and acts as the Command fallback for processes that
+        // have no command line (e.g. System, Idle).
+        let file_name = image_fallback(&proc);
 
         // The snapshot SID saves an `OpenProcessToken`; the token is only
         // opened for processes the snapshot could not name.
@@ -155,6 +165,7 @@ pub fn collect_proc(
         ret.push(ProcessInfo {
             pid: proc.pid,
             command,
+            file_name,
             ppid: proc.ppid,
             start_time: filetime_to_local(proc.create_time),
             cpu_info: CpuInfo {
@@ -174,6 +185,7 @@ pub fn collect_proc(
             groups: groups.unwrap_or_default(),
             priority,
             thread: proc.thread_count,
+            session: proc.session_id as i32,
             interval,
         });
     }
@@ -203,14 +215,21 @@ pub fn collect_proc(
                 None => (thread.kernel_time, thread.user_time),
             };
 
-            let (command, user, groups) = {
+            let (command, file_name, user, groups, session) = {
                 let parent = &ret[owner];
-                (parent.command.clone(), parent.user, parent.groups.clone())
+                (
+                    parent.command.clone(),
+                    parent.file_name.clone(),
+                    parent.user,
+                    parent.groups.clone(),
+                    parent.session,
+                )
             };
 
             ret.push(ProcessInfo {
                 pid: thread.tid,
                 command,
+                file_name,
                 ppid: thread.pid,
                 start_time: filetime_to_local(thread.create_time),
                 cpu_info: CpuInfo {
@@ -230,6 +249,7 @@ pub fn collect_proc(
                 groups,
                 priority: thread.priority,
                 thread: 1,
+                session,
                 interval,
             });
         }
@@ -247,6 +267,7 @@ struct ProcSnapshot {
     ppid: i32,
     thread_count: i32,
     image_name: String,
+    session_id: u32,
     create_time: i64,
     kernel_time: u64,
     user_time: u64,
@@ -311,6 +332,7 @@ fn take_snapshot(with_thread: bool) -> SystemSnapshot {
             ppid,
             thread_count: info.NumberOfThreads as i32,
             image_name,
+            session_id: info.SessionId,
             create_time: info.CreateTime,
             kernel_time: info.KernelTime as u64,
             user_time: info.UserTime as u64,

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -145,10 +145,7 @@ pub fn collect_proc(
 
         // The snapshot SID saves an `OpenProcessToken`; the token is only
         // opened for processes the snapshot could not name.
-        let user = proc
-            .user_sid
-            .clone()
-            .or_else(|| handles.full.and_then(get_user));
+        let user = proc.user_sid.or_else(|| handles.full.and_then(get_user));
         let groups = handles.full.and_then(get_groups);
         let priority = proc.base_priority;
 
@@ -205,11 +202,7 @@ pub fn collect_proc(
 
             let (command, user, groups) = {
                 let parent = &ret[owner];
-                (
-                    parent.command.clone(),
-                    parent.user.clone(),
-                    parent.groups.clone(),
-                )
+                (parent.command.clone(), parent.user, parent.groups.clone())
             };
 
             ret.push(ProcessInfo {

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -6,6 +6,7 @@ use std::ffi::c_void;
 use std::mem::{MaybeUninit, zeroed};
 use std::path::PathBuf;
 use std::ptr;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE};
@@ -64,6 +65,7 @@ pub struct ProcessInfo {
     pub cpu_info: CpuInfo,
     pub memory_info: MemoryInfo,
     pub disk_info: DiskInfo,
+    pub net_info: NetInfo,
     pub user: Option<SID_MAX>,
     pub groups: Vec<SID_MAX>,
     pub priority: i32,
@@ -119,6 +121,18 @@ pub struct DiskInfo {
     pub curr_write: u64,
 }
 
+/// Cumulative network traffic sampled at both ends of the interval.
+///
+/// `ProcessNetworkIoInformation` is a Windows 11 addition and needs a process
+/// handle, so both the class and the process can be missing: the counters stay
+/// at zero then and the rate comes out as zero.
+pub struct NetInfo {
+    pub prev_recv: u64,
+    pub prev_send: u64,
+    pub curr_recv: u64,
+    pub curr_send: u64,
+}
+
 pub struct CpuInfo {
     pub prev_sys: u64,
     pub prev_user: u64,
@@ -168,11 +182,9 @@ pub fn collect_proc(
             // A recycled pid would otherwise pair up with an unrelated process.
             .filter(|p| p.create_time == proc.create_time || proc.create_time == 0);
 
-        let (prev_sys, prev_user, prev_read, prev_write) = match prev {
-            Some(p) => (p.kernel_time, p.user_time, p.read, p.write),
-            // Started between the two samples: report no delta.
-            None => (proc.kernel_time, proc.user_time, proc.read, proc.write),
-        };
+        // A process that started between the two samples pairs with itself,
+        // which reports no delta.
+        let prev = prev.unwrap_or(&proc);
 
         let handles = ProcHandles::open(proc.pid);
 
@@ -199,18 +211,25 @@ pub fn collect_proc(
             ppid: proc.ppid,
             start_time: filetime_to_local(proc.create_time),
             cpu_info: CpuInfo {
-                prev_sys,
-                prev_user,
+                prev_sys: prev.kernel_time,
+                prev_user: prev.user_time,
                 curr_sys: proc.kernel_time,
                 curr_user: proc.user_time,
             },
-            memory_info: proc.memory_info,
             disk_info: DiskInfo {
-                prev_read,
-                prev_write,
+                prev_read: prev.read,
+                prev_write: prev.write,
                 curr_read: proc.read,
                 curr_write: proc.write,
             },
+            net_info: NetInfo {
+                prev_recv: prev.recv,
+                prev_send: prev.send,
+                curr_recv: proc.recv,
+                curr_send: proc.send,
+            },
+            // Last: this moves out of `proc`, which `prev` may still borrow.
+            memory_info: proc.memory_info,
             user,
             groups: groups.unwrap_or_default(),
             priority,
@@ -276,6 +295,14 @@ pub fn collect_proc(
                     curr_read: 0,
                     curr_write: 0,
                 },
+                // Network traffic is only accounted per process, so a thread
+                // row reports none rather than repeating its process'.
+                net_info: NetInfo {
+                    prev_recv: 0,
+                    prev_send: 0,
+                    curr_recv: 0,
+                    curr_send: 0,
+                },
                 user,
                 groups,
                 priority: thread.priority,
@@ -305,6 +332,10 @@ struct ProcSnapshot {
     user_time: u64,
     read: u64,
     write: u64,
+    /// Cumulative network bytes received / sent, when the class that reports
+    /// them is implemented and the process could be opened.
+    recv: u64,
+    send: u64,
     memory_info: MemoryInfo,
     base_priority: i32,
     /// Scheduler state of the most active thread.
@@ -337,10 +368,23 @@ fn take_snapshot(with_thread: bool) -> SystemSnapshot {
         return SystemSnapshot { procs, threads };
     };
 
+    // `ProcessNetworkIoInformation` is a Windows 11 addition: on an older
+    // build no handle is opened for it at all.
+    let want_net = network_counters_supported();
+
     for entry in buffer.iter() {
         let info = entry.info();
+        let pid = info.UniqueProcessId as usize as i32;
         let ppid = info.InheritedFromUniqueProcessId as usize as i32;
         let image_name = entry.image_name();
+
+        // Unlike the rest of the snapshot, the network counters are read from
+        // the process itself, which costs an `OpenProcess` each.
+        let (recv, send) = if want_net {
+            network_counters(pid)
+        } else {
+            (0, 0)
+        };
 
         // Hide the kernel's own processes. The full snapshot's classification is
         // authoritative - a non-zero `SYSTEM_PROCESS_CLASSIFICATION` marks System,
@@ -353,7 +397,7 @@ fn take_snapshot(with_thread: bool) -> SystemSnapshot {
             || (ppid == 4 && !image_name.contains('.'));
 
         procs.push(ProcSnapshot {
-            pid: info.UniqueProcessId as usize as i32,
+            pid,
             ppid,
             thread_count: info.NumberOfThreads as i32,
             image_name,
@@ -363,6 +407,8 @@ fn take_snapshot(with_thread: bool) -> SystemSnapshot {
             user_time: info.UserTime as u64,
             read: info.IoCounters.ReadTransferCount,
             write: info.IoCounters.WriteTransferCount,
+            recv,
+            send,
             memory_info: MemoryInfo {
                 page_fault_count: u64::from(info.VirtualMemoryCounters.PageFaultCount),
                 peak_working_set_size: info.VirtualMemoryCounters.PeakWorkingSetSize as u64,
@@ -392,6 +438,43 @@ fn take_snapshot(with_thread: bool) -> SystemSnapshot {
     }
 
     SystemSnapshot { procs, threads }
+}
+
+/// Whether `ProcessNetworkIoInformation` answers on this machine.
+///
+/// The class is implemented from Windows 11 on, so the answer depends on the
+/// OS build alone: it is probed once against this process - whose handle
+/// carries every access right, so a failure means the class is missing rather
+/// than the handle being too weak - and remembered. An older build then pays
+/// nothing instead of an `OpenProcess` and a rejected query per process and
+/// per sample.
+fn network_counters_supported() -> bool {
+    const UNKNOWN: u8 = 0;
+    const YES: u8 = 1;
+    const NO: u8 = 2;
+    static SUPPORTED: AtomicU8 = AtomicU8::new(UNKNOWN);
+
+    match SUPPORTED.load(Ordering::Acquire) {
+        YES => true,
+        NO => false,
+        _ => {
+            // SAFETY: the pseudo-handle needs no closing.
+            let handle = unsafe { GetCurrentProcess() };
+            let yes = ntapi::process_network_counters(handle).is_some();
+            SUPPORTED.store(if yes { YES } else { NO }, Ordering::Release);
+            yes
+        }
+    }
+}
+
+/// The cumulative network counters of `pid`, or `(0, 0)` when the handle
+/// cannot be opened or the class is not implemented.
+fn network_counters(pid: i32) -> (u64, u64) {
+    let handles = ProcHandles::open(pid);
+    match handles.any().and_then(ntapi::process_network_counters) {
+        Some(counters) => (counters.BytesIn, counters.BytesOut),
+        None => (0, 0),
+    }
 }
 
 /// Idle and System have no command line and, depending on privileges, no

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -41,6 +41,9 @@ pub use super::ntapi::process_image_machine;
 /// Re-export the PEB address query so callers can use
 /// `crate::process::process_peb_address`.
 pub use super::ntapi::process_peb_address;
+/// Re-export the cross-process memory reader so columns can read
+/// PEB-relative data.
+pub use super::ntapi::read_process_memory;
 /// Re-export the `KTHREAD_STATE` constants so the State column can map
 /// them to letters.
 pub use super::ntapi::thread_state;

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -23,6 +23,9 @@ use super::ntapi;
 
 /// Re-export the owned SID type so callers can use `crate::process::SID_MAX`.
 pub use super::ntapi::SID_MAX;
+/// Re-export the decoded thread record so callers can use
+/// `crate::process::ThreadSnapshot`.
+pub use super::ntapi::ThreadSnapshot;
 /// Re-export the image machine query so callers can use
 /// `crate::process::process_image_machine`.
 pub use super::ntapi::process_image_machine;
@@ -285,15 +288,6 @@ struct ProcSnapshot {
     is_kthread: bool,
 }
 
-struct ThreadSnapshot {
-    tid: i32,
-    pid: i32,
-    create_time: i64,
-    kernel_time: u64,
-    user_time: u64,
-    priority: i32,
-}
-
 struct SystemSnapshot {
     procs: Vec<ProcSnapshot>,
     threads: Vec<ThreadSnapshot>,
@@ -361,21 +355,7 @@ fn take_snapshot(with_thread: bool) -> SystemSnapshot {
         });
 
         if with_thread {
-            let pid = info.UniqueProcessId as usize as i32;
-            let slice = entry.threads();
-            for idx in 0..slice.len() {
-                let Some(thread) = slice.get(idx) else {
-                    continue;
-                };
-                threads.push(ThreadSnapshot {
-                    tid: thread.tid,
-                    pid,
-                    create_time: thread.create_time,
-                    kernel_time: thread.kernel_time,
-                    user_time: thread.user_time,
-                    priority: thread.priority,
-                });
-            }
+            threads.extend(entry.threads());
         }
     }
 

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -26,9 +26,18 @@ pub use super::ntapi::SID_MAX;
 /// Re-export the decoded thread record so callers can use
 /// `crate::process::ThreadSnapshot`.
 pub use super::ntapi::ThreadSnapshot;
+/// Re-export the scheduler state so callers can use
+/// `crate::process::ThreadState`.
+pub use super::ntapi::ThreadState;
 /// Re-export the image machine query so callers can use
 /// `crate::process::process_image_machine`.
 pub use super::ntapi::process_image_machine;
+/// Re-export the `KTHREAD_STATE` constants so the State column can map
+/// them to letters.
+pub use super::ntapi::thread_state;
+/// Re-export the `KWAIT_REASON` constants so the State column can map
+/// them to letters.
+pub use super::ntapi::wait_reason;
 
 pub struct ProcessInfo {
     pub pid: i32,
@@ -48,6 +57,12 @@ pub struct ProcessInfo {
     pub priority: i32,
     pub thread: i32,
     pub session: i32,
+    /// Scheduler state of the most active thread behind this row.
+    ///
+    /// Windows publishes no state for a process as a whole, only for each of
+    /// its threads, so the State column derives the row's state from the most
+    /// active one. For a `--thread` row it is that one thread's state.
+    pub state: Option<ThreadState>,
     pub interval: Duration,
 }
 
@@ -189,6 +204,7 @@ pub fn collect_proc(
             priority,
             thread: proc.thread_count,
             session: proc.session_id as i32,
+            state: proc.state,
             interval,
         });
     }
@@ -253,6 +269,7 @@ pub fn collect_proc(
                 priority: thread.priority,
                 thread: 1,
                 session,
+                state: Some(thread.state),
                 interval,
             });
         }
@@ -278,6 +295,8 @@ struct ProcSnapshot {
     write: u64,
     memory_info: MemoryInfo,
     base_priority: i32,
+    /// Scheduler state of the most active thread.
+    state: Option<ThreadState>,
     /// Process user SID straight from the snapshot, when it carried one.
     /// `None` means the token has to be opened to learn the user.
     user_sid: Option<SID_MAX>,
@@ -350,6 +369,7 @@ fn take_snapshot(with_thread: bool) -> SystemSnapshot {
                 private_usage: info.PrivatePageCount as u64,
             },
             base_priority: info.BasePriority,
+            state: entry.state(),
             user_sid: entry.user_sid(),
             is_kthread,
         });

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -21,6 +21,12 @@ use windows_sys::Win32::System::Threading::{
 
 use super::ntapi;
 
+/// Re-export the PEB prefix so the WorkDir column can read
+/// `ProcessParameters`.
+pub use super::ntapi::PEB_PREFIX;
+/// Re-export the process-parameters prefix so the WorkDir column can read
+/// `CurrentDirectory`.
+pub use super::ntapi::RTL_USER_PROCESS_PARAMETERS_PREFIX;
 /// Re-export the owned SID type so callers can use `crate::process::SID_MAX`.
 pub use super::ntapi::SID_MAX;
 /// Re-export the decoded thread record so callers can use
@@ -35,15 +41,6 @@ pub use super::ntapi::process_image_machine;
 /// Re-export the PEB address query so callers can use
 /// `crate::process::process_peb_address`.
 pub use super::ntapi::process_peb_address;
-/// Re-export the PEB prefix so the WorkDir column can read
-/// `ProcessParameters`.
-pub use super::ntapi::PEB_PREFIX;
-/// Re-export the process-parameters prefix so the WorkDir column can read
-/// `CurrentDirectory`.
-pub use super::ntapi::RTL_USER_PROCESS_PARAMETERS_PREFIX;
-/// Re-export the `UNICODE_STRING` so the WorkDir column can read the
-/// current-directory string.
-pub use super::ntapi::UNICODE_STRING;
 /// Re-export the `KTHREAD_STATE` constants so the State column can map
 /// them to letters.
 pub use super::ntapi::thread_state;

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -32,6 +32,18 @@ pub use super::ntapi::ThreadState;
 /// Re-export the image machine query so callers can use
 /// `crate::process::process_image_machine`.
 pub use super::ntapi::process_image_machine;
+/// Re-export the PEB address query so callers can use
+/// `crate::process::process_peb_address`.
+pub use super::ntapi::process_peb_address;
+/// Re-export the PEB prefix so the WorkDir column can read
+/// `ProcessParameters`.
+pub use super::ntapi::PEB_PREFIX;
+/// Re-export the process-parameters prefix so the WorkDir column can read
+/// `CurrentDirectory`.
+pub use super::ntapi::RTL_USER_PROCESS_PARAMETERS_PREFIX;
+/// Re-export the `UNICODE_STRING` so the WorkDir column can read the
+/// current-directory string.
+pub use super::ntapi::UNICODE_STRING;
 /// Re-export the `KTHREAD_STATE` constants so the State column can map
 /// them to letters.
 pub use super::ntapi::thread_state;

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -23,6 +23,9 @@ use super::ntapi;
 
 /// Re-export the owned SID type so callers can use `crate::process::SID_MAX`.
 pub use super::ntapi::SID_MAX;
+/// Re-export the image machine query so callers can use
+/// `crate::process::process_image_machine`.
+pub use super::ntapi::process_image_machine;
 
 pub struct ProcessInfo {
     pub pid: i32,

--- a/src/util.rs
+++ b/src/util.rs
@@ -282,22 +282,6 @@ pub unsafe fn get_sys_value(
     ) == 0
 }
 
-#[cfg(target_os = "windows")]
-pub fn format_sid(sid: &[u64], abbr: bool) -> String {
-    let mut ret = format!("S-{}-{}-{}", sid[0], sid[1], sid[2]);
-    if sid.len() > 3 {
-        if abbr {
-            ret = format!("{}-...-{}", ret, sid[sid.len() - 1]);
-        } else {
-            for s in sid.iter().skip(3) {
-                ret = format!("{}-{}", ret, s);
-            }
-        }
-    }
-
-    ret
-}
-
 pub fn bytify(x: u64) -> String {
     let byte = Byte::from_u64(x);
     let byte = byte.get_appropriate_unit(UnitType::Binary);


### PR DESCRIPTION
Majar improvements done after

* [Added] Arch column for Windows (process image architecture)
* [Added] Real Command column for Windows (command line arguments). This column was printing pure file name, which is now moved to FileName column.
* [Added] RtPriority column for Windows (kernel base priority)
* [Added] Threads column for Windows (thread count)
* [Added] Session column for Windows (session ID)
* [Added] State column for Windows (scheduler state derived from thread states)
* [Added] Env column for Windows (environment variables)
* [Added] RecvBytes and SendBytes columns for Windows (network I/O rate; needs Windows 11 or later)
* [Added] WorkDir column for Windows (current working directory)

---

Clarification: I made the high-level design, and let AI write the code (with my small fixes here and there). It's still carefully tested and benchmarked.

---

## Summary

Rewrites the Windows process backend around a single `NtQuerySystemInformation` (NQSI) snapshot, replacing the previous per-process `OpenProcess` → `GetProcessTimes` / `GetProcessMemoryInfo` / `GetProcessIoCounters` / `GetPriorityClass` / `EnumProcessModulesEx` walk. This cuts the syscall count from O(N × k) to O(1) for the enumeration phase and eliminates the race window where a process could exit between individual queries.

## Changes

### Performance

- **Single-snapshot enumeration.** All per-process metrics (memory, CPU times, I/O counters, image name, thread count, PPID) are now read from one NQSI buffer. The old code opened each process handle *twice* (once for the delta baseline, once for the final read) and issued ~6 syscalls per handle.
- **Lazy SID-to-name resolution.** `LookupAccountSidW` is deferred to column render time (`SID_MAX::display_name()`) and cached per SID value, instead of being called eagerly for every process during collection. This saves several milliseconds when many groups are present (especially for system processes).
- **Elevated fast path.** When running with admin privileges, `SystemFullProcessInformation` (class 148) is used. It embeds each process's user SID directly in the snapshot, saving one `OpenProcessToken` + `GetTokenInformation` round-trip per process.

### Correctness / bug fixes

- **System processes are no longer silently dropped.** The old code required *every* field (`command`, `start_time`, `cpu_info`, `memory_info`, `disk_info`, `user`, `groups`, `thread`) to be non-`None` (`all_ok` gate); any `OpenProcess` failure (e.g. `System`, `Registry`, `Memory Compression`) caused the entire entry to be skipped. NQSI returns memory, CPU, I/O and image name for *all* processes including kernel threads, so they are now always listed. User / Group columns are left empty when the token cannot be opened.
- **Handle leaks fixed.** `OpenProcessToken` handles were never closed in `get_user` / `get_groups` / `set_privilege`. Process handles are now managed by a `ProcHandles` RAII wrapper with a `Drop` impl.
- **SID name cache keyed by value, not pointer.** The old `HashMap<PSID, _>` cache was keyed by the address of a transient allocation; once freed, the address could be recycled by the next query and return a different account's name. The cache is now keyed by `SID_MAX` (an owned, fixed-size 68-byte SID) with value equality.
- **Command lines fetched via `NtQueryInformationProcess(ProcessCommandLineInformation)`** instead of `EnumProcessModulesEx` + `GetModuleBaseNameW`, which only returned the bare executable name. Fixes #752.

### Other

- **`SID_MAX` value type.** SIDs are stored as a fixed-size `#[repr(C)]` struct (embedding the official `SID` header + padding to `SECURITY_MAX_SID_SIZE`) instead of `Vec<u64>`, removing per-SID heap allocations and enabling `Hash` / `Eq` by live bytes.
- **Memory total** now comes from `GlobalMemoryStatusEx` (`ullTotalPhys`) instead of `GetPerformanceInfo` (`PhysicalTotal × PageSize`). This reduced one system DLL dependency after the previous `EnumProcessModulesEx`, `GetModuleBaseNameW` and `GetPerformanceInfo` removal.

## Screenshots

### Before, with or without admin permission

<img width="1142" height="1614" alt="old-noadmin" src="https://github.com/user-attachments/assets/457be144-abf7-4af3-a854-a225612e5021" />

### After, without admin permission

<img width="1388" height="1604" alt="new-noadmin" src="https://github.com/user-attachments/assets/7206aa43-8deb-41cf-a8bc-0fed3d4b748e" />

### After, with admin permission

<img width="1872" height="1628" alt="new-admin" src="https://github.com/user-attachments/assets/8bb8a39b-67d2-409b-9a06-570f23a8d4b5" />

## Benchmark

```
$ hyperfine.exe -w 10 -S none c:/users/zhang/procs.old.exe c:/users/zhang/procs.new.exe
Benchmark 1: c:/users/zhang/procs.old.exe
  Time (mean ± σ):     156.2 ms ±   2.9 ms    [User: 21.7 ms, System: 20.0 ms]
  Range (min … max):   150.2 ms … 160.7 ms    18 runs

Benchmark 2: c:/users/zhang/procs.new.exe
  Time (mean ± σ):     143.6 ms ±   2.6 ms    [User: 17.2 ms, System: 25.0 ms]
  Range (min … max):   136.9 ms … 147.9 ms    20 runs

Summary
  c:/users/zhang/procs.new.exe ran
    1.09 ± 0.03 times faster than c:/users/zhang/procs.old.exe
```

Despite `procs.new.exe` reports about 2x more processes than `procs.old.exe`

## Disclamer

[`NtQuerySystemInformation`](https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntquerysysteminformation) and [`NtQueryInformationProcess`](https://learn.microsoft.com/en-us/windows/win32/api/winternl/nf-winternl-ntqueryinformationprocess) are so called `Native API`, which are partially documented only. This PR does use some undocumented features.

---

<details>
<summary>My original PR message if you prefer</summary>

1. Processes are enumerated around a single `NtQuerySystemInformation` (NQSI) snapshot instead of the previous per-process handle/token/module walk. This greatly reduced syscalls (`GetProcessMemoryInfo`, `GetProcessTimes`, `GetProcessIoCounters`, `GetPriorityClass`, `EnumProcessModulesEx`) per process, and therefore improved performance and reduced risks that processes may exit between syscalls.
2. System processes are no longer dropped silently. Thanks to NQSI, memory info, CPU times, IO counters and process name are always available to all processes (including system processes and kernel threads), so we don't need to drop them. User / Group info is not available from the regular NQSI(SystemProcessInformation) call though. For system processes which we don't have to permission to open, User / Group info is left empty.
3. When elevated, the advanced syscall NQSI(SystemFullProcessInformation) is used, which contains SID for system processes we don't even have permission to open with administrator permission. And since the syscall contains User SID, one more OpenProcessToken/GetTokenInformation is saved.
4. Command lines are fetched via `NtQueryInformationProcess(ProcessCommandLineInformation)` for processes we have permission to open. Fixes #752
5. User / Group info is now lazily fetched. This saved a few milliseconds since Windows applies multiple groups to one process, especially for system processes.
6. Several bugs are fixed.
    1. The handles returned by OpenProcessToken are now correctly closed.
    2. SID caches are now keyed by value instead of pointer.

</details>