### PR TITLE
fix: ReadBytes / WriteBytes divided by a mis-scaled interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/dalance/procs/compare/v0.14.12...Unreleased) - ReleaseDate
 
+* [Fixed] ReadBytes / WriteBytes divided by a mis-scaled interval (seconds added to milliseconds)
+
 ## [v0.14.12](https://github.com/dalance/procs/compare/v0.14.11...v0.14.12) - 2026-06-25
 
 * [Added] Add fancy regex fallback for advanced filters [#913](https://github.com/dalance/procs/pull/913)

--- a/src/columns/read_bytes.rs
+++ b/src/columns/read_bytes.rs
@@ -32,7 +32,7 @@ impl Column for ReadBytes {
         let (fmt_content, raw_content) = if let Some(curr_io) = proc.curr_io
             && let Some(prev_io) = proc.prev_io
         {
-            let interval_ms = proc.interval.as_secs() + u64::from(proc.interval.subsec_millis());
+            let interval_ms = proc.interval.as_secs() * 1000 + u64::from(proc.interval.subsec_millis());
             let io = (curr_io.read_bytes - prev_io.read_bytes) * 1000 / interval_ms;
             (bytify(io), io)
         } else {
@@ -50,7 +50,7 @@ impl Column for ReadBytes {
 impl Column for ReadBytes {
     fn add(&mut self, proc: &ProcessInfo) {
         let (fmt_content, raw_content) = if proc.curr_res.is_some() && proc.prev_res.is_some() {
-            let interval_ms = proc.interval.as_secs() + u64::from(proc.interval.subsec_millis());
+            let interval_ms = proc.interval.as_secs() * 1000 + u64::from(proc.interval.subsec_millis());
             let io = (proc.curr_res.as_ref().unwrap().ri_diskio_bytesread
                 - proc.prev_res.as_ref().unwrap().ri_diskio_bytesread)
                 * 1000
@@ -70,7 +70,7 @@ impl Column for ReadBytes {
 #[cfg(target_os = "windows")]
 impl Column for ReadBytes {
     fn add(&mut self, proc: &ProcessInfo) {
-        let interval_ms = proc.interval.as_secs() + u64::from(proc.interval.subsec_millis());
+        let interval_ms = proc.interval.as_secs() * 1000 + u64::from(proc.interval.subsec_millis());
         let io = (proc.disk_info.curr_read - proc.disk_info.prev_read) * 1000 / interval_ms;
 
         let raw_content = io;
@@ -88,7 +88,7 @@ impl Column for ReadBytes {
     fn add(&mut self, proc: &ProcessInfo) {
         // io block size: 128KB
         let block_size = 128 * 1024;
-        let interval_ms = proc.interval.as_secs() + u64::from(proc.interval.subsec_millis());
+        let interval_ms = proc.interval.as_secs() * 1000 + u64::from(proc.interval.subsec_millis());
         let io = (proc.curr_proc.info.rusage.inblock as u64
             - proc.prev_proc.info.rusage.inblock as u64)
             * block_size

--- a/src/columns/write_bytes.rs
+++ b/src/columns/write_bytes.rs
@@ -32,7 +32,7 @@ impl Column for WriteBytes {
         let (fmt_content, raw_content) = if let Some(curr_io) = proc.curr_io
             && let Some(prev_io) = proc.prev_io
         {
-            let interval_ms = proc.interval.as_secs() + u64::from(proc.interval.subsec_millis());
+            let interval_ms = proc.interval.as_secs() * 1000 + u64::from(proc.interval.subsec_millis());
             let io = (curr_io.write_bytes - prev_io.write_bytes) * 1000 / interval_ms;
             (bytify(io), io)
         } else {
@@ -50,7 +50,7 @@ impl Column for WriteBytes {
 impl Column for WriteBytes {
     fn add(&mut self, proc: &ProcessInfo) {
         let (fmt_content, raw_content) = if proc.curr_res.is_some() && proc.prev_res.is_some() {
-            let interval_ms = proc.interval.as_secs() + u64::from(proc.interval.subsec_millis());
+            let interval_ms = proc.interval.as_secs() * 1000 + u64::from(proc.interval.subsec_millis());
             let io = (proc.curr_res.as_ref().unwrap().ri_diskio_byteswritten
                 - proc.prev_res.as_ref().unwrap().ri_diskio_byteswritten)
                 * 1000
@@ -70,7 +70,7 @@ impl Column for WriteBytes {
 #[cfg(target_os = "windows")]
 impl Column for WriteBytes {
     fn add(&mut self, proc: &ProcessInfo) {
-        let interval_ms = proc.interval.as_secs() + u64::from(proc.interval.subsec_millis());
+        let interval_ms = proc.interval.as_secs() * 1000 + u64::from(proc.interval.subsec_millis());
         let io = (proc.disk_info.curr_write - proc.disk_info.prev_write) * 1000 / interval_ms;
 
         let raw_content = io;
@@ -88,7 +88,7 @@ impl Column for WriteBytes {
     fn add(&mut self, proc: &ProcessInfo) {
         // io block size: 128KB
         let block_size = 128 * 1024;
-        let interval_ms = proc.interval.as_secs() + u64::from(proc.interval.subsec_millis());
+        let interval_ms = proc.interval.as_secs() * 1000 + u64::from(proc.interval.subsec_millis());
         let io = (proc.curr_proc.info.rusage.oublock as u64
             - proc.prev_proc.info.rusage.oublock as u64)
             * block_size


### PR DESCRIPTION
... seconds added to milliseconds, which reported a rate up to 1000x too high as soon as the sampling interval reached one second

Found by AI