### PR TITLE
add WorkDir column support on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [Added] Env column for Windows (environment variables)
 * [Added] RecvBytes and SendBytes columns for Windows (network I/O rate; needs Windows 11 or later)
 * [Added] WorkDir column for Windows (current working directory)
+* [Added] WorkDir column for macOS (current working directory)
 * [Added] `--thread` support for Windows
 * [Changed] Group and Gid columns for Windows read the process token only when the column is displayed
 * [Fixed] ReadBytes / WriteBytes divided by a mis-scaled interval (seconds added to milliseconds)

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ The first `[[columns]]` is shown at left side, and the last is shown at right si
 | VmTotal              | -not supported-       | Total virtual memory size                     | *[^*] | o     | *[^*]   | *[^*]   |
 | VoluntaryContextSw   | -not supported-       | Voluntary context switch count                | o     |       |         | o       |
 | Wchan                | wchan                 | Process sleeping kernel function              | o     |       |         | o       |
-| WorkDir              | -not supported-       | Current working directory                     | o     |       | o       |         |
+| WorkDir              | -not supported-       | Current working directory                     | o     | o     | o       |         |
 | WriteByte            | -not supported-       | Write bytes to storage                        | o     | o     | o       | o       |
 
 [^*]: Alias for VmRss on these platforms

--- a/src/columns/os_macos.rs
+++ b/src/columns/os_macos.rs
@@ -44,6 +44,7 @@ pub mod user_saved;
 pub mod vm_rss;
 pub mod vm_size;
 pub mod vm_total;
+pub mod work_dir;
 pub mod write_bytes;
 
 pub use self::arch::Arch;
@@ -92,6 +93,7 @@ pub use self::user_saved::UserSaved;
 pub use self::vm_rss::VmRss;
 pub use self::vm_size::VmSize;
 pub use self::vm_total::VmTotal;
+pub use self::work_dir::WorkDir;
 pub use self::write_bytes::WriteBytes;
 
 use crate::column::Column;
@@ -152,6 +154,7 @@ pub enum ConfigColumnKind {
     VmRss,
     VmSize,
     VmTotal,
+    WorkDir,
     WriteBytes,
 }
 
@@ -166,7 +169,7 @@ pub fn gen_column(
     separator: &str,
     abbr_sid: bool,
     tree_symbols: &[String; 5],
-    _procfs: Option<PathBuf>,
+    procfs: Option<PathBuf>,
 ) -> Box<dyn Column> {
     match kind {
         ConfigColumnKind::Arch => Box::new(Arch::new(header)),
@@ -218,6 +221,7 @@ pub fn gen_column(
         ConfigColumnKind::VmRss => Box::new(VmRss::new(header)),
         ConfigColumnKind::VmSize => Box::new(VmSize::new(header)),
         ConfigColumnKind::VmTotal => Box::new(VmTotal::new(header)),
+        ConfigColumnKind::WorkDir => Box::new(WorkDir::new(header, procfs)),
         ConfigColumnKind::WriteBytes => Box::new(WriteBytes::new(header)),
     }
 }
@@ -322,6 +326,10 @@ pub static KIND_LIST: Lazy<BTreeMap<ConfigColumnKind, (&'static str, &'static st
             (
                 ConfigColumnKind::VmTotal,
                 ("VmTotal", "Total footprint size"),
+            ),
+            (
+                ConfigColumnKind::WorkDir,
+                ("WorkDir", "Current working directory"),
             ),
             (
                 ConfigColumnKind::WriteBytes,
@@ -660,6 +668,9 @@ style = "ByUnit"
 [[columns]]
 kind = "VmSize"
 style = "ByUnit"
+[[columns]]
+kind = "WorkDir"
+style = "White"
 [[columns]]
 kind = "WriteBytes"
 style = "White"

--- a/src/columns/work_dir.rs
+++ b/src/columns/work_dir.rs
@@ -13,7 +13,6 @@ pub struct WorkDir {
     fmt_contents: HashMap<i32, String>,
     raw_contents: HashMap<i32, String>,
     width: usize,
-    #[allow(dead_code)]
     procfs: Option<PathBuf>,
 }
 
@@ -32,18 +31,9 @@ impl WorkDir {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android"))]
 impl Column for WorkDir {
     fn add(&mut self, proc: &ProcessInfo) {
-        let fmt_content = if let Ok(proc) = crate::util::process_new(proc.pid, &self.procfs) {
-            if let Ok(path) = proc.cwd() {
-                path.to_string_lossy().to_string()
-            } else {
-                String::from("")
-            }
-        } else {
-            String::from("")
-        };
+        let fmt_content = work_dir_of(proc.pid, &self.procfs).unwrap_or_default();
         let raw_content = fmt_content.clone();
 
         self.fmt_contents.insert(proc.pid, fmt_content);
@@ -53,17 +43,10 @@ impl Column for WorkDir {
     column_default!(String, false);
 }
 
-#[cfg(target_os = "windows")]
-impl Column for WorkDir {
-    fn add(&mut self, proc: &ProcessInfo) {
-        let fmt_content = work_dir_of(proc.pid).unwrap_or_default();
-        let raw_content = fmt_content.clone();
-
-        self.fmt_contents.insert(proc.pid, fmt_content);
-        self.raw_contents.insert(proc.pid, raw_content);
-    }
-
-    column_default!(String, false);
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn work_dir_of(pid: i32, procfs: &Option<PathBuf>) -> Option<String> {
+    let proc = crate::util::process_new(pid, procfs).ok()?;
+    Some(proc.cwd().ok()?.to_string_lossy().into_owned())
 }
 
 /// Reads the current working directory of `pid` from its PEB.
@@ -74,7 +57,7 @@ impl Column for WorkDir {
 /// `PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_VM_READ`, so protected
 /// processes (e.g. PPL) yield `None`.
 #[cfg(target_os = "windows")]
-fn work_dir_of(pid: i32) -> Option<String> {
+fn work_dir_of(pid: i32, _procfs: &Option<PathBuf>) -> Option<String> {
     use windows_sys::Win32::Foundation::{CloseHandle, FALSE, HANDLE};
     use windows_sys::Win32::System::Threading::{
         OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_VM_READ,

--- a/src/columns/work_dir.rs
+++ b/src/columns/work_dir.rs
@@ -4,6 +4,8 @@ use std::cmp;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+#[cfg(target_os = "macos")]
+use libproc::libproc::proc_pid::{PIDInfo, PidInfoFlavor, pidinfo};
 #[cfg(target_os = "windows")]
 use windows_sys::Win32::Foundation::HANDLE;
 
@@ -47,6 +49,29 @@ impl Column for WorkDir {
 fn work_dir_of(pid: i32, procfs: &Option<PathBuf>) -> Option<String> {
     let proc = crate::util::process_new(pid, procfs).ok()?;
     Some(proc.cwd().ok()?.to_string_lossy().into_owned())
+}
+
+/// libproc's `pidinfo` passes `&mut T` to `proc_pidinfo` sized by
+/// `size_of::<T>()`, so this must keep the exact layout of
+/// `proc_vnodepathinfo`.
+#[cfg(target_os = "macos")]
+#[repr(transparent)]
+struct VnodePathInfo(libc::proc_vnodepathinfo);
+
+#[cfg(target_os = "macos")]
+impl PIDInfo for VnodePathInfo {
+    fn flavor() -> PidInfoFlavor {
+        PidInfoFlavor::VNodePathInfo
+    }
+}
+
+/// Processes owned by other users yield `None` unless running as root.
+#[cfg(target_os = "macos")]
+fn work_dir_of(pid: i32, _procfs: &Option<PathBuf>) -> Option<String> {
+    let info = pidinfo::<VnodePathInfo>(pid, 0).ok()?;
+    // libc declares `vip_path` as `[[c_char; 32]; 32]`, not `[c_char; MAXPATHLEN]`.
+    let path = crate::util::ptr_to_cstr(info.0.pvi_cdir.vip_path.as_flattened()).ok()?;
+    Some(path.to_string_lossy().into_owned())
 }
 
 /// Reads the current working directory of `pid` from its PEB.

--- a/src/util.rs
+++ b/src/util.rs
@@ -359,9 +359,7 @@ thread_local! {
     pub static USERS_CACHE: std::cell::RefCell<UsersCache> = UsersCache::new().into();
 }
 
-#[cfg(target_os = "freebsd")]
-// std::ffi::FromBytesUntilNulError is missing until Rust 1.73.0
-// https://github.com/rust-lang/rust/pull/113701
+#[cfg(any(target_os = "freebsd", target_os = "macos"))]
 pub fn ptr_to_cstr(
     x: &[std::os::raw::c_char],
 ) -> Result<&std::ffi::CStr, core::ffi::FromBytesUntilNulError> {


### PR DESCRIPTION
libproc's `pidcwd()` is still a stub on macOS (it always returns `Err`), so the
column goes through `proc_pidinfo(PROC_PIDVNODEPATHINFO)` directly. libc already
ships `proc_vnodepathinfo`, so all that's needed is a `#[repr(transparent)]`
newtype implementing libproc's `PIDInfo`, and the column can use the same
`pidinfo::<T>()` call the rest of `process/macos.rs` uses. No new dependencies.

The first commit is a small cleanup of `work_dir.rs`: the Linux and Windows
blocks had identical `add()` bodies and only differed in how the path is looked
up, so now there's one `impl Column` and a per-platform
`work_dir_of(pid, procfs)`. No behaviour change, and it drops the
`#[allow(dead_code)]` on the `procfs` field. I only have a Mac here, so CI is
the real check for that commit on Linux/Windows.

The lookup happens lazily in `add()` like the Windows implementation, so nothing
is paid unless the column is actually configured. Other users' processes come
back empty without root, same as the other macOS columns.

Also flips the macOS cell in the README support matrix and adds a CHANGELOG
line.

Tested on macOS 26 / arm64: `procs -i WorkDir` shows `/` for system daemons and
the right cwd for my shells, `cargo test` passes, clippy and fmt are clean (the
remaining warnings are the pre-existing `unsafe_op_in_unsafe_fn` ones in
`process/macos.rs` and `util.rs`).
