### PR TITLE
Avoid exhausting file descriptors while collecting Linux processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [Changed] Group and Gid columns for Windows read the process token only when the column is displayed
 * [Fixed] ReadBytes / WriteBytes divided by a mis-scaled interval (seconds added to milliseconds)
 * [Fixed] Fix invalid JSON output when a column is skipped by --only or --tree
+* [Fixed] Avoid silently omitting Linux processes when the open file limit is low
 
 ## [v0.14.12](https://github.com/dalance/procs/compare/v0.14.11...v0.14.12) - 2026-06-25
 

--- a/src/process/linux.rs
+++ b/src/process/linux.rs
@@ -85,10 +85,9 @@ pub fn collect_proc(
     with_thread: bool,
     show_kthreads: bool,
     procfs_path: &Option<PathBuf>,
-) -> Vec<ProcessInfo> {
+) -> impl Iterator<Item = ProcessInfo> + '_ {
     let mut base_procs = Vec::new();
     let mut base_tasks = HashMap::new();
-    let mut ret = Vec::new();
 
     let all_proc = if let Some(x) = procfs_path {
         procfs::process::all_processes_with_root(x)
@@ -111,85 +110,73 @@ pub fn collect_proc(
 
     thread::sleep(interval);
 
-    for (pid, prev_stat, prev_io, prev_time) in base_procs {
-        let curr_proc = if let Ok(proc) = crate::util::process_new(pid, procfs_path) {
-            proc
-        } else {
-            continue;
-        };
+    base_procs
+        .into_iter()
+        .filter_map(move |(pid, prev_stat, prev_io, prev_time)| {
+            let curr_proc = crate::util::process_new(pid, procfs_path).ok()?;
+            let curr_stat = curr_proc.stat().ok()?;
+            let curr_owner = curr_proc.uid().ok()?;
 
-        let curr_stat = if let Ok(stat) = curr_proc.stat() {
-            stat
-        } else {
-            continue;
-        };
+            let curr_io = curr_proc.io().ok();
+            let curr_status = curr_proc.status().ok();
+            let curr_time = Instant::now();
+            let interval = curr_time - prev_time;
+            let ppid = curr_stat.ppid;
 
-        let curr_owner = if let Ok(owner) = curr_proc.uid() {
-            owner
-        } else {
-            continue;
-        };
-
-        let curr_io = curr_proc.io().ok();
-        let curr_status = curr_proc.status().ok();
-        let curr_time = Instant::now();
-        let interval = curr_time - prev_time;
-        let ppid = curr_stat.ppid;
-
-        if !show_kthreads
-            && curr_stat
-                .flags()
-                .unwrap_or(StatFlags::empty())
-                .contains(StatFlags::PF_KTHREAD)
-        {
-            continue;
-        }
-
-        let mut curr_tasks = HashMap::new();
-        if with_thread && let Ok(iter) = curr_proc.tasks() {
-            collect_task(iter, &mut curr_tasks);
-        }
-
-        let curr_proc = ProcessTask::Process {
-            stat: curr_stat,
-            owner: curr_owner,
-            proc: curr_proc,
-        };
-
-        let proc = ProcessInfo {
-            pid,
-            ppid,
-            curr_proc,
-            prev_stat,
-            curr_io,
-            prev_io,
-            curr_status,
-            interval,
-        };
-
-        ret.push(proc);
-
-        for (tid, (pid, curr_stat, curr_status, curr_io)) in curr_tasks {
-            if let Some((_, prev_stat, _, prev_io)) = base_tasks.remove(&tid) {
-                let proc = ProcessInfo {
-                    pid: tid,
-                    ppid: pid,
-                    curr_proc: ProcessTask::Task {
-                        stat: curr_stat,
-                        owner: curr_owner,
-                    },
-                    prev_stat,
-                    curr_io,
-                    prev_io,
-                    curr_status,
-                    interval,
-                };
-                ret.push(proc);
+            if !show_kthreads
+                && curr_stat
+                    .flags()
+                    .unwrap_or(StatFlags::empty())
+                    .contains(StatFlags::PF_KTHREAD)
+            {
+                return None;
             }
-        }
-    }
 
-    ret
+            let mut curr_tasks = HashMap::new();
+            if with_thread && let Ok(iter) = curr_proc.tasks() {
+                collect_task(iter, &mut curr_tasks);
+            }
+
+            let curr_proc = ProcessTask::Process {
+                stat: curr_stat,
+                owner: curr_owner,
+                proc: curr_proc,
+            };
+
+            let proc = ProcessInfo {
+                pid,
+                ppid,
+                curr_proc,
+                prev_stat,
+                curr_io,
+                prev_io,
+                curr_status,
+                interval,
+            };
+
+            let mut tasks = Vec::new();
+
+            for (tid, (pid, curr_stat, curr_status, curr_io)) in curr_tasks {
+                if let Some((_, prev_stat, _, prev_io)) = base_tasks.remove(&tid) {
+                    let proc = ProcessInfo {
+                        pid: tid,
+                        ppid: pid,
+                        curr_proc: ProcessTask::Task {
+                            stat: curr_stat,
+                            owner: curr_owner,
+                        },
+                        prev_stat,
+                        curr_io,
+                        prev_io,
+                        curr_status,
+                        interval,
+                    };
+                    tasks.push(proc);
+                }
+            }
+            Some(std::iter::once(proc).chain(tasks))
+        })
+        .flatten()
 }
 
 #[allow(clippy::type_complexity)]

--- a/src/view.rs
+++ b/src/view.rs
@@ -182,16 +182,15 @@ impl View {
             config.display.show_kthreads,
             &opt.procfs,
         );
-        for c in columns.iter_mut() {
-            for p in &proc {
-                c.column.add(p);
-            }
-        }
-
         let mut parent_pids = HashMap::new();
         let mut child_pids = HashMap::<i32, Vec<i32>>::new();
-        if opt.tree || !config.display.show_self_parents {
-            for p in &proc {
+        // Consume each process before collecting the next so Linux /proc handles
+        // are released instead of accumulating until every process is collected.
+        for p in proc {
+            for c in columns.iter_mut() {
+                c.column.add(&p);
+            }
+            if opt.tree || !config.display.show_self_parents {
                 parent_pids.insert(p.pid, p.ppid);
                 if let Some(x) = child_pids.get_mut(&p.ppid) {
                     x.push(p.pid);

--- a/tests/low_fd_limit.rs
+++ b/tests/low_fd_limit.rs
@@ -1,0 +1,183 @@
+#![cfg(any(target_os = "linux", target_os = "android"))]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::io;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct Fixture(PathBuf);
+
+impl Fixture {
+    fn new() -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("procs-low-fd-{}-{unique}", std::process::id()));
+        fs::create_dir(&path).unwrap();
+        Self(path)
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
+
+fn write_stat(path: &Path, pid: i32, ppid: i32, kernel_thread: bool) {
+    let mut fields = vec!["0".to_string(); 49];
+    fields[0] = ppid.to_string(); // ppid, field 4
+    if kernel_thread {
+        fields[5] = "2097152".to_string(); // PF_KTHREAD, field 9
+    }
+    fields[16] = "2".to_string(); // num_threads, field 20
+    fields[18] = "1".to_string(); // starttime, field 22
+    fs::write(path, format!("{pid} (comm-{pid}) S {}\n", fields.join(" "))).unwrap();
+}
+
+fn run_procs(root: &Path, args: &[&str], fd_limit: libc::rlim_t) -> String {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_procs"));
+    command
+        .arg("--load-config")
+        .arg(root.join("config.toml"))
+        .arg("--procfs")
+        .arg(root.join("proc"))
+        .args([
+            "--color",
+            "disable",
+            "--theme",
+            "dark",
+            "--pager",
+            "disable",
+            "--no-header",
+            "--interval",
+            "0",
+        ])
+        .args(args);
+
+    // Only the child running procs gets a lower limit. The pre-exec callback
+    // uses resource-limit syscalls without allocation or locks after fork.
+    unsafe {
+        command.pre_exec(move || {
+            let mut limit = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            if libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            limit.rlim_cur = fd_limit.min(limit.rlim_max);
+            if libc::setrlimit(libc::RLIMIT_NOFILE, &limit) != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn lists_all_processes_with_a_low_file_descriptor_limit() {
+    let fixture = Fixture::new();
+    let procfs = fixture.0.join("proc");
+    fs::create_dir(&procfs).unwrap();
+    let pids = 900001..900097;
+    for pid in pids.clone() {
+        let process = procfs.join(pid.to_string());
+        fs::create_dir(&process).unwrap();
+        let ppid = if pid == pids.start { 1 } else { pids.start };
+        write_stat(&process.join("stat"), pid, ppid, pid >= 900089);
+        fs::write(
+            process.join("cmdline"),
+            format!("fixture-{pid}\0--from-cmdline\0"),
+        )
+        .unwrap();
+        for tid in [pid, pid + 1000000] {
+            let task = process.join("task").join(tid.to_string());
+            fs::create_dir_all(&task).unwrap();
+            write_stat(&task.join("stat"), tid, ppid, false);
+        }
+    }
+
+    for (args, with_threads, show_kthreads) in [
+        (vec![], false, true),
+        (vec!["--thread"], true, true),
+        (vec!["--tree"], true, true),
+        (vec!["--thread"], true, false),
+    ] {
+        fs::write(
+            fixture.0.join("config.toml"),
+            format!(
+                r#"[[columns]]
+kind = "Pid"
+[[columns]]
+kind = "TreeSlot"
+[[columns]]
+kind = "Command"
+[display]
+show_self = true
+show_self_parents = true
+show_kthreads = {show_kthreads}
+"#,
+            ),
+        )
+        .unwrap();
+        let expected: BTreeSet<_> = pids
+            .clone()
+            .filter(|&pid| show_kthreads || pid < 900089)
+            .flat_map(|pid| {
+                let mut ids = vec![pid];
+                if with_threads {
+                    ids.push(pid + 1000000);
+                }
+                ids
+            })
+            .collect();
+        let control = run_procs(&fixture.0, &args, 1024);
+        let output = run_procs(&fixture.0, &args, 32);
+        let actual: BTreeSet<i32> = output
+            .lines()
+            .map(|line| {
+                line.split_whitespace()
+                    .find_map(|word| word.trim_matches(['[', ']']).parse().ok())
+                    .unwrap_or_else(|| panic!("no PID in {line:?}, args={args:?}"))
+            })
+            .collect();
+        assert_eq!(
+            actual, expected,
+            "args={args:?}, show_kthreads={show_kthreads}"
+        );
+        for pid in &expected {
+            let command = if pids.contains(pid) {
+                format!("fixture-{pid} --from-cmdline")
+            } else {
+                format!("comm-{pid}")
+            };
+            assert!(
+                output.contains(&command),
+                "missing command for {pid}, args={args:?}"
+            );
+        }
+        assert_eq!(
+            output, control,
+            "args={args:?}, show_kthreads={show_kthreads}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #766. Related: #743.

The second sampling pass retains every `procfs::Process` until the columns are populated. Each owns a directory descriptor, so a low open-file limit silently truncates the result.

Collect Linux samples lazily and populate all columns and parent maps for each process before advancing. This keeps the existing handle-based reads, without adding extra PID-based reopenings or changing resource limits. Other platforms keep their existing collectors.

The regression test builds a synthetic procfs tree with 96 processes and their threads, then runs the CLI with a child-only `RLIMIT_NOFILE=32`. It covers normal output, threads, tree output, kernel-thread filtering and command-line reads. Output must match the 1024-descriptor control. On the original code, the first case shows only 28 of 96 processes.

Validation:
- Rust 1.88.0 and 1.98.0, default and no-default features: all test binaries pass in private PID namespaces (25 tests with default features, 20 without, for each version).
- Rust 1.98.0: `cargo clippy --locked --all-targets -- -D warnings`, also with `--no-default-features`; formatting passes.
- A network-isolated, non-root container with 97 real processes: all 97 remain visible at limits 16, 32 and 1024; all 100 entries appear with threads or tree mode. TCP/UDP ports and working directories are preserved. Checked with both Rust versions.
- With 4096 synthetic processes, the original needs the higher limit to list them all and reaches 4100 observed open descriptors. The change lists all 4096 at a limit of 32, with an observed peak of 6 descriptors.
